### PR TITLE
chore: dummy test PR - verify Devin access

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ var (
 	// to appropriate values for the compiled binary.
 	version string = "dev"
 
-	// goreleaser can pass other information to the main package, such as the specific commit
+	// goreleaser can pass other information to the main package, such as the specific commit.
 	// https://goreleaser.com/cookbooks/using-main.version/
 )
 


### PR DESCRIPTION
# chore: dummy test PR - verify Devin access

## Summary
Adds a period to a comment in `main.go` (line 29). This is a no-op change created solely to verify that Devin can access the repo, run lint, and open a draft PR.

## Review & Testing Checklist for Human
- [ ] Confirm this draft PR should **not** be merged — it exists only to validate tooling access

### Notes
- Lint (`golangci-lint run`) passes cleanly
- Link to Devin run: https://eon.devinenterprise.com/sessions/713af838e1604cb1bdb9eff02115b93c
- Requested by: @SivanAfek