### PR TITLE
feat: add internal condition bypass to ListSourceAccounts and ListRestoreAccounts

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -12,6 +12,14 @@ import (
 	externalEonSdkAPI "github.com/eon-io/eon-sdk-go"
 )
 
+// Condition represents a query condition for internal bypass of filters
+type Condition struct {
+	Property   string      `json:"property,omitempty,omitzero"`
+	Operator   string      `json:"operator"`
+	Value      []string    `json:"value,omitempty,omitzero"`
+	Conditions []Condition `json:"conditions,omitempty,omitzero"`
+}
+
 // APIError represents an error from the Eon API with HTTP status code
 type APIError struct {
 	StatusCode int
@@ -64,10 +72,15 @@ func (c *EonClient) handleAPIError(err error, httpResp *http.Response, baseError
 	return nil
 }
 
-// ListSourceAccounts retrieves all source accounts for the project
-func (c *EonClient) ListSourceAccounts(ctx context.Context) ([]externalEonSdkAPI.SourceAccount, error) {
+// ListSourceAccounts retrieves all source accounts for the project.
+// If a condition is provided, it is sent as an internal bypass that ignores filters.
+func (c *EonClient) ListSourceAccounts(ctx context.Context, condition *Condition) ([]externalEonSdkAPI.SourceAccount, error) {
 	if err := c.tokenRefresher.EnsureValidToken(); err != nil {
 		return nil, fmt.Errorf("failed to ensure valid token: %w", err)
+	}
+
+	if condition != nil {
+		return c.listSourceAccountsWithCondition(ctx, condition)
 	}
 
 	resp, httpResp, err := c.client.AccountsAPI.ListSourceAccounts(ctx, c.projectID).ListSourceAccountsRequest(externalEonSdkAPI.ListSourceAccountsRequest{}).Execute()
@@ -89,10 +102,63 @@ func (c *EonClient) ListSourceAccounts(ctx context.Context) ([]externalEonSdkAPI
 	return resp.GetAccounts(), nil
 }
 
-// ListRestoreAccounts retrieves all restore accounts for the project
-func (c *EonClient) ListRestoreAccounts(ctx context.Context) ([]externalEonSdkAPI.RestoreAccount, error) {
+func (c *EonClient) listSourceAccountsWithCondition(ctx context.Context, condition *Condition) ([]externalEonSdkAPI.SourceAccount, error) {
+	baseURL := c.client.GetConfig().Servers[0].URL
+	url := fmt.Sprintf("%s/v1/projects/%s/source-accounts/list", baseURL, c.projectID)
+
+	reqBody := struct {
+		Condition *Condition `json:"condition"`
+	}{Condition: condition}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+
+	for key, value := range c.client.GetConfig().DefaultHeader {
+		httpReq.Header.Set(key, value)
+	}
+
+	httpResp, err := c.client.GetConfig().HTTPClient.Do(httpReq)
+	if apiErr := c.handleAPIError(err, httpResp, "failed to list source accounts"); apiErr != nil {
+		return nil, apiErr
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(httpResp.Body)
+		return nil, fmt.Errorf("API error %d: %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var resp externalEonSdkAPI.ListSourceAccountsResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if resp.GetAccounts() == nil {
+		return []externalEonSdkAPI.SourceAccount{}, nil
+	}
+
+	return resp.GetAccounts(), nil
+}
+
+// ListRestoreAccounts retrieves all restore accounts for the project.
+// If a condition is provided, it is sent as an internal bypass that ignores filters.
+func (c *EonClient) ListRestoreAccounts(ctx context.Context, condition *Condition) ([]externalEonSdkAPI.RestoreAccount, error) {
 	if err := c.tokenRefresher.EnsureValidToken(); err != nil {
 		return nil, fmt.Errorf("failed to ensure valid token: %w", err)
+	}
+
+	if condition != nil {
+		return c.listRestoreAccountsWithCondition(ctx, condition)
 	}
 
 	resp, httpResp, err := c.client.AccountsAPI.ListRestoreAccounts(ctx, c.projectID).ListRestoreAccountsRequest(externalEonSdkAPI.ListRestoreAccountsRequest{}).Execute()
@@ -105,6 +171,54 @@ func (c *EonClient) ListRestoreAccounts(ctx context.Context) ([]externalEonSdkAP
 	if httpResp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResp.Body)
 		return nil, fmt.Errorf("API error %d: %s", httpResp.StatusCode, string(body))
+	}
+
+	if resp.GetAccounts() == nil {
+		return []externalEonSdkAPI.RestoreAccount{}, nil
+	}
+
+	return resp.GetAccounts(), nil
+}
+
+func (c *EonClient) listRestoreAccountsWithCondition(ctx context.Context, condition *Condition) ([]externalEonSdkAPI.RestoreAccount, error) {
+	baseURL := c.client.GetConfig().Servers[0].URL
+	url := fmt.Sprintf("%s/v1/projects/%s/restore-accounts/list", baseURL, c.projectID)
+
+	reqBody := struct {
+		Condition *Condition `json:"condition"`
+	}{Condition: condition}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+
+	for key, value := range c.client.GetConfig().DefaultHeader {
+		httpReq.Header.Set(key, value)
+	}
+
+	httpResp, err := c.client.GetConfig().HTTPClient.Do(httpReq)
+	if apiErr := c.handleAPIError(err, httpResp, "failed to list restore accounts"); apiErr != nil {
+		return nil, apiErr
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(httpResp.Body)
+		return nil, fmt.Errorf("API error %d: %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var resp externalEonSdkAPI.ListRestoreAccountsResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 
 	if resp.GetAccounts() == nil {

--- a/internal/provider/data_source_restore_accounts.go
+++ b/internal/provider/data_source_restore_accounts.go
@@ -108,7 +108,7 @@ func (d *RestoreAccountsDataSource) Configure(ctx context.Context, req datasourc
 func (d *RestoreAccountsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data RestoreAccountsDataSourceModel
 
-	accounts, err := d.client.ListRestoreAccounts(ctx)
+	accounts, err := d.client.ListRestoreAccounts(ctx, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read restore accounts: %s", err))
 		return

--- a/internal/provider/data_source_source_accounts.go
+++ b/internal/provider/data_source_source_accounts.go
@@ -107,7 +107,7 @@ func (d *SourceAccountsDataSource) Configure(ctx context.Context, req datasource
 func (d *SourceAccountsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data SourceAccountsDataSourceModel
 
-	accounts, err := d.client.ListSourceAccounts(ctx)
+	accounts, err := d.client.ListSourceAccounts(ctx, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read source accounts: %s", err))
 		return

--- a/internal/provider/resource_restore_account.go
+++ b/internal/provider/resource_restore_account.go
@@ -265,7 +265,7 @@ func (r *RestoreAccountResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	accounts, err := r.client.ListRestoreAccounts(ctx)
+	accounts, err := r.client.ListRestoreAccounts(ctx, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read restore accounts: %s", err))
 		return
@@ -384,7 +384,7 @@ func (r *RestoreAccountResource) Delete(ctx context.Context, req resource.Delete
 func (r *RestoreAccountResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 
-	accounts, err := r.client.ListRestoreAccounts(ctx)
+	accounts, err := r.client.ListRestoreAccounts(ctx, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read restore accounts during import: %s", err))
 		return
@@ -466,7 +466,7 @@ func (r *RestoreAccountResource) ImportState(ctx context.Context, req resource.I
 // findExistingAccountID attempts to find the ID of an existing restore account
 // that matches the given configuration. Returns empty string if not found.
 func (r *RestoreAccountResource) findExistingAccountID(ctx context.Context, cloudProvider CloudProvider, data RestoreAccountResourceModel) string {
-	accounts, err := r.client.ListRestoreAccounts(ctx)
+	accounts, err := r.client.ListRestoreAccounts(ctx, nil)
 	if err != nil {
 		tflog.Debug(ctx, "Failed to list restore accounts to find existing ID", map[string]any{
 			"error": err.Error(),

--- a/internal/provider/resource_source_account.go
+++ b/internal/provider/resource_source_account.go
@@ -262,7 +262,7 @@ func (r *SourceAccountResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	accounts, err := r.client.ListSourceAccounts(ctx)
+	accounts, err := r.client.ListSourceAccounts(ctx, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read source accounts: %s", err))
 		return
@@ -375,7 +375,7 @@ func (r *SourceAccountResource) Delete(ctx context.Context, req resource.DeleteR
 func (r *SourceAccountResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 
-	accounts, err := r.client.ListSourceAccounts(ctx)
+	accounts, err := r.client.ListSourceAccounts(ctx, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read source accounts during import: %s", err))
 		return
@@ -452,7 +452,7 @@ func (r *SourceAccountResource) ImportState(ctx context.Context, req resource.Im
 // findExistingAccountID attempts to find the ID of an existing source account
 // that matches the given configuration. Returns empty string if not found.
 func (r *SourceAccountResource) findExistingAccountID(ctx context.Context, cloudProvider CloudProvider, data SourceAccountResourceModel) string {
-	accounts, err := r.client.ListSourceAccounts(ctx)
+	accounts, err := r.client.ListSourceAccounts(ctx, nil)
 	if err != nil {
 		tflog.Debug(ctx, "Failed to list source accounts to find existing ID", map[string]interface{}{
 			"error": err.Error(),


### PR DESCRIPTION
## Summary

Adds an optional `*Condition` parameter to `ListSourceAccounts` and `ListRestoreAccounts` in the Eon client. When a condition is provided, the client bypasses the SDK and sends a raw HTTP POST request with the condition directly in the request body. This supports an internal bypass mechanism where condition-based queries skip the normal filter pipeline on the server side.

All existing callers are updated to pass `nil`, preserving current behavior.

**Companion server-side PR:** https://github.com/eon-io/eon-service/pull/23515

## Review & Testing Checklist for Human

- [ ] **Auth in custom HTTP path**: The `listSourceAccountsWithCondition` / `listRestoreAccountsWithCondition` methods copy headers from `DefaultHeader` but bypass the SDK's request pipeline. Verify this is sufficient for authentication (same pattern as `StartBigQueryDatasetRestore`). If the SDK injects auth tokens outside of `DefaultHeader`, the condition path will fail silently with 401s.
- [ ] **No pagination in condition path**: The raw HTTP requests don't pass `pageToken`/`pageSize`. Confirm this is acceptable, or whether large result sets could be silently truncated.
- [ ] **Deployment order**: This PR depends on the server-side condition support (eon-service#23515) being deployed first. Sending a condition to an older server that doesn't recognize the field should be harmless (server ignores unknown JSON fields), but verify this assumption.

### Notes
- Link to Devin run: https://eon.devinenterprise.com/sessions/e4a5a5bd5c24494a860a41acf0eb07fd
- Requested by: @SivanAfek