### PR TITLE
(EON-7281) feat(backup-management): update account_id operator docs for string operators

### DIFF
--- a/docs/resources/backup_policy.md
+++ b/docs/resources/backup_policy.md
@@ -715,7 +715,7 @@ Optional:
 Required:
 
 - `account_ids` (List of String) List of account IDs
-- `operator` (String) Operator: 'IN' or 'NOT_IN'
+- `operator` (String) Operator: 'IN', 'NOT_IN', 'STARTS_WITH', 'NOT_STARTS_WITH', 'ENDS_WITH', 'NOT_ENDS_WITH', 'CONTAINS', or 'NOT_CONTAINS'
 
 
 <a id="nestedatt--resource_selector--expression--group--operands--apps"></a>

--- a/internal/provider/resource_backup_policy.go
+++ b/internal/provider/resource_backup_policy.go
@@ -462,7 +462,7 @@ func (r *BackupPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 													Optional:            true,
 													Attributes: map[string]schema.Attribute{
 														"operator": schema.StringAttribute{
-															MarkdownDescription: "Operator: 'IN' or 'NOT_IN'",
+															MarkdownDescription: "Operator: 'IN', 'NOT_IN', 'STARTS_WITH', 'NOT_STARTS_WITH', 'ENDS_WITH', 'NOT_ENDS_WITH', 'CONTAINS', or 'NOT_CONTAINS'",
 															Required:            true,
 														},
 														"account_ids": schema.ListAttribute{


### PR DESCRIPTION
# (EON-7281) feat(backup-management): update account_id operator docs for string operators

## Summary

Updates the Terraform schema documentation for the `account_id` backup policy condition to reflect newly supported string operators. The `operator` field description now lists `STARTS_WITH`, `NOT_STARTS_WITH`, `ENDS_WITH`, `NOT_ENDS_WITH`, `CONTAINS`, and `NOT_CONTAINS` in addition to the existing `IN`/`NOT_IN`.

This is a **documentation-only change** — the provider already passes operator strings through to the API via `ScalarOperators(...)` cast, so no functional code change is needed. This is a companion to [eon-io/eon-service#23745](https://github.com/eon-io/eon-service/pull/23745) which adds the backend and frontend support for these operators on the `accountId` property.

Changes:
- Updated `MarkdownDescription` for `account_id.operator` in `resource_backup_policy.go`
- Regenerated `docs/resources/backup_policy.md` via `go generate ./...`

## Review & Testing Checklist for Human

- [ ] **Companion PR dependency**: Verify [eon-io/eon-service#23745](https://github.com/eon-io/eon-service/pull/23745) is merged before or alongside this PR, since these new operators require the backend `accountId` property to be registered as a `String` type. Documenting operators that don't work yet could mislead users.
- [ ] **Operator passthrough assumption**: Confirm that the `ScalarOperators(...)` cast in the SDK's `AccountIdCondition` model does indeed pass through string operator values (like `STARTS_WITH`) to the API without validation errors. This was inferred from the `ResourceNameCondition` pattern but not tested end-to-end with the terraform provider.
- [ ] **Terraform plan test**: Apply a backup policy with `account_id` condition using `STARTS_WITH` operator and confirm it round-trips correctly (create → read → no diff on plan).

### Notes
- Requested by: @oryanomer1
- [Link to Devin Session](https://eon.devinenterprise.com/sessions/826e28924f6a48579cba41fc06f87792)