### PR TITLE
(EON-5698) test: verify backup policies unit tests pass on CI

### DIFF
--- a/internal/provider/data_source_backup_policies_unit_test.go
+++ b/internal/provider/data_source_backup_policies_unit_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 // TestBackupPoliciesDataSource_Unit tests the data source creation without API calls
+// Verify these tests pass on CI before introducing new changes
 func TestBackupPoliciesDataSource_Unit(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
No-op change (single comment addition) to trigger CI and verify the existing `data_source_backup_policies_unit_test.go` tests pass on `main` before introducing EON-5698 changes to the backup policy APIs in `eon-service`.

## Review & Testing Checklist for Human
- [ ] Verify all CI checks pass — that's the sole purpose of this PR
- [ ] Once confirmed, this PR can be closed without merging (it's a validation-only PR)

### Notes
- All 7 test functions in the file passed locally before pushing
- This PR is intentionally trivial; the goal is CI validation of existing tests, not a code change

Link to Devin session: https://eon.devinenterprise.com/sessions/0d99637f138d416f9ff9cfa9ce647e78
Requested by: @SivanAfek
<!-- devin-review-badge-begin -->

---

<a href="https://eon.devinenterprise.com/review/eon-io/terraform-provider-eon/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
