### PR TITLE
(EON-8377) fix: read role from API response in restore account create

### DIFF
--- a/internal/provider/resource_restore_account.go
+++ b/internal/provider/resource_restore_account.go
@@ -242,10 +242,14 @@ func (r *RestoreAccountResource) Create(ctx context.Context, req resource.Create
 	data.CreatedAt = types.StringValue(time.Now().Format(time.RFC3339))
 	data.UpdatedAt = types.StringValue(time.Now().Format(time.RFC3339))
 
-	// Set role to null by default, override for AWS (backward compatibility)
+	// Populate role from API response (not plan data, which may be unknown during replace)
 	data.Role = types.StringNull()
-	if cloudProvider == CloudProviderAWS && data.Aws != nil {
-		data.Role = data.Aws.RoleArn
+	if cloudProvider == CloudProviderAWS && account.RestoreAccountAttributes.HasAws() {
+		awsAttrs := account.RestoreAccountAttributes.GetAws()
+		data.Role = types.StringValue(awsAttrs.GetRoleArn())
+		if data.Aws != nil {
+			data.Aws.RoleArn = types.StringValue(awsAttrs.GetRoleArn())
+		}
 	}
 
 	tflog.Debug(ctx, "Restore account connected", map[string]interface{}{


### PR DESCRIPTION
## Summary
- The `Create` function for `eon_restore_account` was copying `role` from plan data (`data.Aws.RoleArn`), which can be "unknown" when `role_arn` depends on a resource replaced in the same apply (e.g. `replace_triggered_by`)
- Terraform then fails with `Provider returned invalid result object after apply` because unknown values are not allowed after create
- Now reads `role` from the API response, matching how `Read` and `ImportState` already work

## Test plan
- [ ] `terraform apply` with `replace_triggered_by = [aws_iam_role.eon_restore_account_role]` no longer fails
- [ ] Backward compat: deprecated `role` field still populated correctly after create

🤖 Generated with [Claude Code](https://claude.com/claude-code)