### PR TITLE
(EON-9082) feat: auto-reconnect and in-place update for source accounts

### DIFF
--- a/docs/resources/source_account.md
+++ b/docs/resources/source_account.md
@@ -100,7 +100,7 @@ output "gcp_production_account" {
 - `created_at` (String) Date and time the source account was connected to the Eon project.
 - `id` (String) Eon-assigned account ID.
 - `provider_account_id` (String, Deprecated) Cloud-provider-assigned account ID (AWS account ID or Azure subscription ID). Computed from the `aws` or `azure` block.
-- `status` (String) Connection status of the AWS account, Azure subscription, or GCP project. Only `CONNECTED` source accounts can be backed up. Possible values: `CONNECTED`, `DISCONNECTED`, `INSUFFICIENT_PERMISSIONS`.
+- `status` (String) Connection status of the source account. The provider automatically reconnects accounts that drift to `DISCONNECTED`. Possible values: `CONNECTED`, `DISCONNECTED`, `INSUFFICIENT_PERMISSIONS`.
 - `updated_at` (String) Date and time the source account was last updated.
 
 <a id="nestedblock--aws"></a>

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.4
 
 require (
-	github.com/eon-io/eon-sdk-go v1.116.0
+	github.com/eon-io/eon-sdk-go v1.117.0
 	github.com/hashicorp/terraform-plugin-docs v0.24.0
 	github.com/hashicorp/terraform-plugin-framework v1.13.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/eon-io/eon-sdk-go v1.116.0 h1:DG15D66lgwRdJdBfMUvVLUtrJ5VH+BnYnleLCnkH2Dc=
-github.com/eon-io/eon-sdk-go v1.116.0/go.mod h1:NWrS3rllESPQ7vzryT7+bHkOpNrXbXcnRtaPlv0LScw=
+github.com/eon-io/eon-sdk-go v1.117.0 h1:OI/8uxdUc1rAoXg5scTLfvkIl7SioD5eLCSnbF9gW1s=
+github.com/eon-io/eon-sdk-go v1.117.0/go.mod h1:NWrS3rllESPQ7vzryT7+bHkOpNrXbXcnRtaPlv0LScw=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -215,26 +215,6 @@ type UpdateAwsSourceAccountAttributes struct {
 	RoleArn *string
 }
 
-// updateSourceAccountAPIBody matches the API's expected JSON structure for
-// PATCH /v1/projects/{projectId}/source-accounts/{accountId}.
-type updateSourceAccountAPIBody struct {
-	Name                    *string                          `json:"name,omitempty"`
-	SourceAccountAttributes *updateSourceAccountAPIAttrsBody `json:"sourceAccountAttributes,omitempty"`
-}
-
-type updateSourceAccountAPIAttrsBody struct {
-	Aws *updateAwsAPIBody `json:"aws,omitempty"`
-}
-
-type updateAwsAPIBody struct {
-	RoleArn *string `json:"roleArn,omitempty"`
-}
-
-// updateSourceAccountAPIResponse wraps the API response.
-type updateSourceAccountAPIResponse struct {
-	SourceAccount externalEonSdkAPI.SourceAccount `json:"sourceAccount"`
-}
-
 // UpdateSourceAccount updates mutable fields of a source account via
 // PATCH /v1/projects/{projectId}/source-accounts/{accountId}.
 func (c *EonClient) UpdateSourceAccount(ctx context.Context, accountId string, req UpdateSourceAccountRequest) (*externalEonSdkAPI.SourceAccount, error) {
@@ -242,51 +222,34 @@ func (c *EonClient) UpdateSourceAccount(ctx context.Context, accountId string, r
 		return nil, fmt.Errorf("failed to ensure valid token: %w", err)
 	}
 
-	body := updateSourceAccountAPIBody{Name: req.Name}
+	sdkReq := externalEonSdkAPI.NewUpdateSourceAccountRequest()
+	if req.Name != nil {
+		sdkReq.SetName(*req.Name)
+	}
 	if req.SourceAccountAttributes != nil && req.SourceAccountAttributes.Aws != nil {
-		body.SourceAccountAttributes = &updateSourceAccountAPIAttrsBody{
-			Aws: &updateAwsAPIBody{
-				RoleArn: req.SourceAccountAttributes.Aws.RoleArn,
-			},
+		attrs := externalEonSdkAPI.NewUpdateSourceAccountAttributesInput()
+		awsAttrs := externalEonSdkAPI.UpdateAwsSourceAccountAttributes{}
+		if req.SourceAccountAttributes.Aws.RoleArn != nil {
+			awsAttrs.SetRoleArn(*req.SourceAccountAttributes.Aws.RoleArn)
 		}
+		attrs.SetAws(awsAttrs)
+		sdkReq.SetSourceAccountAttributes(*attrs)
 	}
 
-	jsonBody, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal update request: %w", err)
-	}
-
-	baseURL := c.client.GetConfig().Servers[0].URL
-	url := fmt.Sprintf("%s/v1/projects/%s/source-accounts/%s", baseURL, c.projectID, accountId)
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewReader(jsonBody))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create update request: %w", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Accept", "application/json")
-	for key, value := range c.client.GetConfig().DefaultHeader {
-		httpReq.Header.Set(key, value)
-	}
-
-	httpResp, err := c.client.GetConfig().HTTPClient.Do(httpReq) // #nosec G704 -- URL is built from trusted server configuration
+	resp, httpResp, err := c.client.AccountsAPI.UpdateSourceAccount(ctx, c.projectID, accountId).
+		UpdateSourceAccountRequest(*sdkReq).Execute()
 	if apiErr := c.handleAPIError(err, httpResp, "failed to update source account"); apiErr != nil {
 		return nil, apiErr
 	}
 	defer httpResp.Body.Close()
 
 	if httpResp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(httpResp.Body)
-		return nil, fmt.Errorf("API error %d: %s", httpResp.StatusCode, string(respBody))
+		body, _ := io.ReadAll(httpResp.Body)
+		return nil, fmt.Errorf("API error %d: %s", httpResp.StatusCode, string(body))
 	}
 
-	var resp updateSourceAccountAPIResponse
-	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
-		// If decoding fails, return nil — the caller re-reads via List anyway.
-		return nil, nil
-	}
-	return &resp.SourceAccount, nil
+	account := resp.GetSourceAccount()
+	return &account, nil
 }
 
 // ReconnectSourceAccount reconnects a previously disconnected source account

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -199,6 +199,49 @@ func (c *EonClient) DisconnectSourceAccount(ctx context.Context, accountId strin
 	return nil
 }
 
+// UpdateSourceAccountRequest contains the fields that can be updated on a source account.
+type UpdateSourceAccountRequest struct {
+	Name                    *string
+	SourceAccountAttributes *UpdateSourceAccountAttributes
+}
+
+// UpdateSourceAccountAttributes contains cloud-provider-specific attributes to update.
+type UpdateSourceAccountAttributes struct {
+	Aws *UpdateAwsSourceAccountAttributes
+}
+
+// UpdateAwsSourceAccountAttributes contains AWS-specific attributes to update.
+type UpdateAwsSourceAccountAttributes struct {
+	RoleArn *string
+}
+
+// UpdateSourceAccount updates mutable fields of a source account.
+// TODO: Replace with real API call when the endpoint is available.
+func (c *EonClient) UpdateSourceAccount(ctx context.Context, accountId string, req UpdateSourceAccountRequest) (*externalEonSdkAPI.SourceAccount, error) {
+	return nil, fmt.Errorf("UpdateSourceAccount API not yet implemented")
+}
+
+// ReconnectSourceAccount reconnects a previously disconnected source account
+func (c *EonClient) ReconnectSourceAccount(ctx context.Context, accountId string) (*externalEonSdkAPI.SourceAccount, error) {
+	if err := c.tokenRefresher.EnsureValidToken(); err != nil {
+		return nil, fmt.Errorf("failed to ensure valid token: %w", err)
+	}
+
+	resp, httpResp, err := c.client.AccountsAPI.ReconnectSourceAccount(ctx, c.projectID, accountId).Execute()
+	if apiErr := c.handleAPIError(err, httpResp, "failed to reconnect source account"); apiErr != nil {
+		return nil, apiErr
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(httpResp.Body)
+		return nil, fmt.Errorf("API error %d: %s", httpResp.StatusCode, string(body))
+	}
+
+	account := resp.GetSourceAccount()
+	return &account, nil
+}
+
 // ListSourceAwsOrganizationalUnits retrieves all source AWS organizational units for the project.
 // It paginates through all pages to return the complete list.
 func (c *EonClient) ListSourceAwsOrganizationalUnits(ctx context.Context) ([]externalEonSdkAPI.SourceAwsOrganizationalUnit, error) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -215,10 +215,78 @@ type UpdateAwsSourceAccountAttributes struct {
 	RoleArn *string
 }
 
-// UpdateSourceAccount updates mutable fields of a source account.
-// TODO: Replace with real API call when the endpoint is available.
+// updateSourceAccountAPIBody matches the API's expected JSON structure for
+// PATCH /v1/projects/{projectId}/source-accounts/{accountId}.
+type updateSourceAccountAPIBody struct {
+	Name                    *string                          `json:"name,omitempty"`
+	SourceAccountAttributes *updateSourceAccountAPIAttrsBody `json:"sourceAccountAttributes,omitempty"`
+}
+
+type updateSourceAccountAPIAttrsBody struct {
+	Aws *updateAwsAPIBody `json:"aws,omitempty"`
+}
+
+type updateAwsAPIBody struct {
+	RoleArn *string `json:"roleArn,omitempty"`
+}
+
+// updateSourceAccountAPIResponse wraps the API response.
+type updateSourceAccountAPIResponse struct {
+	SourceAccount externalEonSdkAPI.SourceAccount `json:"sourceAccount"`
+}
+
+// UpdateSourceAccount updates mutable fields of a source account via
+// PATCH /v1/projects/{projectId}/source-accounts/{accountId}.
 func (c *EonClient) UpdateSourceAccount(ctx context.Context, accountId string, req UpdateSourceAccountRequest) (*externalEonSdkAPI.SourceAccount, error) {
-	return nil, fmt.Errorf("UpdateSourceAccount API not yet implemented")
+	if err := c.tokenRefresher.EnsureValidToken(); err != nil {
+		return nil, fmt.Errorf("failed to ensure valid token: %w", err)
+	}
+
+	body := updateSourceAccountAPIBody{Name: req.Name}
+	if req.SourceAccountAttributes != nil && req.SourceAccountAttributes.Aws != nil {
+		body.SourceAccountAttributes = &updateSourceAccountAPIAttrsBody{
+			Aws: &updateAwsAPIBody{
+				RoleArn: req.SourceAccountAttributes.Aws.RoleArn,
+			},
+		}
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal update request: %w", err)
+	}
+
+	baseURL := c.client.GetConfig().Servers[0].URL
+	url := fmt.Sprintf("%s/v1/projects/%s/source-accounts/%s", baseURL, c.projectID, accountId)
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create update request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+	for key, value := range c.client.GetConfig().DefaultHeader {
+		httpReq.Header.Set(key, value)
+	}
+
+	httpResp, err := c.client.GetConfig().HTTPClient.Do(httpReq) // #nosec G704 -- URL is built from trusted server configuration
+	if apiErr := c.handleAPIError(err, httpResp, "failed to update source account"); apiErr != nil {
+		return nil, apiErr
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(httpResp.Body)
+		return nil, fmt.Errorf("API error %d: %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var resp updateSourceAccountAPIResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+		// If decoding fails, return nil — the caller re-reads via List anyway.
+		return nil, nil
+	}
+	return &resp.SourceAccount, nil
 }
 
 // ReconnectSourceAccount reconnects a previously disconnected source account

--- a/internal/provider/planmodifier_reconnect.go
+++ b/internal/provider/planmodifier_reconnect.go
@@ -7,20 +7,22 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// alwaysConnectedModifier is a plan modifier that always plans "CONNECTED"
-// for the status field. This causes Terraform to detect drift when the API
-// reports a non-CONNECTED status and trigger an Update (reconnect).
-type alwaysConnectedModifier struct{}
+// reconnectIfDisconnectedModifier is a plan modifier that flips the planned
+// status to "CONNECTED" when the state reports "DISCONNECTED". This causes
+// Terraform to detect drift and trigger an Update (which performs a reconnect).
+// Other non-CONNECTED states (e.g. INSUFFICIENT_PERMISSIONS) are preserved
+// as-is since they require manual intervention.
+type reconnectIfDisconnectedModifier struct{}
 
-func (m alwaysConnectedModifier) Description(_ context.Context) string {
-	return "Plans status as CONNECTED so that a disconnected account triggers an update (reconnect)."
+func (m reconnectIfDisconnectedModifier) Description(_ context.Context) string {
+	return "Plans status as CONNECTED when the current state is DISCONNECTED so that the next apply triggers a reconnect."
 }
 
-func (m alwaysConnectedModifier) MarkdownDescription(ctx context.Context) string {
+func (m reconnectIfDisconnectedModifier) MarkdownDescription(ctx context.Context) string {
 	return m.Description(ctx)
 }
 
-func (m alwaysConnectedModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+func (m reconnectIfDisconnectedModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
 	// On create the state is nil — let the API populate the initial value.
 	if req.State.Raw.IsNull() {
 		return
@@ -38,7 +40,9 @@ func (m alwaysConnectedModifier) PlanModifyString(_ context.Context, req planmod
 	resp.PlanValue = req.StateValue
 }
 
-// AlwaysConnected returns a plan modifier that forces the planned value to "CONNECTED".
-func AlwaysConnected() planmodifier.String {
-	return alwaysConnectedModifier{}
+// ReconnectOnDisconnected returns a plan modifier that flips the planned
+// status to "CONNECTED" when the state is "DISCONNECTED", triggering an
+// Update on the next apply so the provider can attempt a reconnect.
+func ReconnectOnDisconnected() planmodifier.String {
+	return reconnectIfDisconnectedModifier{}
 }

--- a/internal/provider/planmodifier_reconnect.go
+++ b/internal/provider/planmodifier_reconnect.go
@@ -1,0 +1,44 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// alwaysConnectedModifier is a plan modifier that always plans "CONNECTED"
+// for the status field. This causes Terraform to detect drift when the API
+// reports a non-CONNECTED status and trigger an Update (reconnect).
+type alwaysConnectedModifier struct{}
+
+func (m alwaysConnectedModifier) Description(_ context.Context) string {
+	return "Plans status as CONNECTED so that a disconnected account triggers an update (reconnect)."
+}
+
+func (m alwaysConnectedModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m alwaysConnectedModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// On create the state is nil — let the API populate the initial value.
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	// Only plan a change when the account is DISCONNECTED.
+	// Other non-CONNECTED states (e.g. INSUFFICIENT_PERMISSIONS) require
+	// manual intervention and should not trigger an automatic reconnect.
+	if req.StateValue.ValueString() == "DISCONNECTED" {
+		resp.PlanValue = types.StringValue("CONNECTED")
+		return
+	}
+
+	// Preserve the current state value for all other statuses.
+	resp.PlanValue = req.StateValue
+}
+
+// AlwaysConnected returns a plan modifier that forces the planned value to "CONNECTED".
+func AlwaysConnected() planmodifier.String {
+	return alwaysConnectedModifier{}
+}

--- a/internal/provider/resource_source_account.go
+++ b/internal/provider/resource_source_account.go
@@ -77,9 +77,9 @@ func (r *SourceAccountResource) Schema(ctx context.Context, req resource.SchemaR
 				DeprecationMessage:  "Use 'aws { role_arn = \"...\" }' instead.",
 			},
 			"status": schema.StringAttribute{
-				MarkdownDescription: "Connection status of the AWS account, Azure subscription, or GCP project. Only `CONNECTED` source accounts can be backed up. Possible values: `CONNECTED`, `DISCONNECTED`, `INSUFFICIENT_PERMISSIONS`.",
+				MarkdownDescription: "Connection status of the source account. The provider automatically reconnects accounts that drift to `DISCONNECTED`. Possible values: `CONNECTED`, `DISCONNECTED`, `INSUFFICIENT_PERMISSIONS`.",
 				Computed:            true,
-				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+				PlanModifiers:       []planmodifier.String{AlwaysConnected()},
 			},
 			"created_at": schema.StringAttribute{
 				MarkdownDescription: "Date and time the source account was connected to the Eon project.",
@@ -346,16 +346,158 @@ func (r *SourceAccountResource) Read(ctx context.Context, req resource.ReadReque
 }
 
 func (r *SourceAccountResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data SourceAccountResourceModel
+	var plan SourceAccountResourceModel
+	var state SourceAccountResourceModel
 
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.AddWarning("Update Not Supported", "Most source account changes require replacement. Please update your configuration to force replacement if needed.")
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	accountId := state.Id.ValueString()
+
+	// Step 1: Update mutable fields (name, role_arn) if changed.
+	updateReq := r.buildUpdateRequest(plan, state)
+	if updateReq != nil {
+		tflog.Info(ctx, "Updating source account", map[string]interface{}{
+			"id": accountId,
+		})
+
+		_, err := r.client.UpdateSourceAccount(ctx, accountId, *updateReq)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Update Failed",
+				fmt.Sprintf("Unable to update source account %s: %s", accountId, err),
+			)
+			return
+		}
+	}
+
+	// Step 2: Reconnect if the account is DISCONNECTED.
+	if state.Status.ValueString() == "DISCONNECTED" {
+		tflog.Info(ctx, "Source account is disconnected, attempting reconnect", map[string]interface{}{
+			"id": accountId,
+		})
+
+		_, err := r.client.ReconnectSourceAccount(ctx, accountId)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Reconnect Failed",
+				fmt.Sprintf("Unable to reconnect source account %s: %s", accountId, err),
+			)
+			return
+		}
+
+		tflog.Info(ctx, "Source account reconnected", map[string]interface{}{
+			"id": accountId,
+		})
+	}
+
+	// Step 3: Read the account back from the API to sync all fields.
+	newState, err := r.readSourceAccount(ctx, accountId, plan)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Read After Update Failed",
+			fmt.Sprintf("Unable to read source account %s after update: %s", accountId, err),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
+}
+
+// buildUpdateRequest compares plan and state and returns an UpdateSourceAccountRequest
+// if any mutable fields changed. Returns nil if nothing needs updating.
+func (r *SourceAccountResource) buildUpdateRequest(plan, state SourceAccountResourceModel) *client.UpdateSourceAccountRequest {
+	var req client.UpdateSourceAccountRequest
+	var changed bool
+
+	if plan.Name.ValueString() != state.Name.ValueString() {
+		name := plan.Name.ValueString()
+		req.Name = &name
+		changed = true
+	}
+
+	if plan.Aws != nil && state.Aws != nil &&
+		plan.Aws.RoleArn.ValueString() != state.Aws.RoleArn.ValueString() {
+		roleArn := plan.Aws.RoleArn.ValueString()
+		req.SourceAccountAttributes = &client.UpdateSourceAccountAttributes{
+			Aws: &client.UpdateAwsSourceAccountAttributes{
+				RoleArn: &roleArn,
+			},
+		}
+		changed = true
+	}
+
+	if !changed {
+		return nil
+	}
+	return &req
+}
+
+// readSourceAccount fetches a source account by ID and maps it to the resource model.
+// The plan is used to preserve user-configured values for fields not returned by the API.
+func (r *SourceAccountResource) readSourceAccount(ctx context.Context, accountId string, plan SourceAccountResourceModel) (*SourceAccountResourceModel, error) {
+	accounts, err := r.client.ListSourceAccounts(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to list source accounts: %w", err)
+	}
+
+	for _, account := range accounts {
+		if account.Id != accountId {
+			continue
+		}
+
+		data := SourceAccountResourceModel{
+			Id:                types.StringValue(account.Id),
+			Name:              types.StringValue(account.GetName()),
+			Status:            types.StringValue(string(account.Status)),
+			ProviderAccountId: types.StringValue(account.GetProviderAccountId()),
+			CreatedAt:         plan.CreatedAt,
+			UpdatedAt:         types.StringValue(time.Now().Format(time.RFC3339)),
+		}
+
+		cloudProvider := CloudProvider(account.SourceAccountAttributes.GetCloudProvider())
+		data.CloudProvider = types.StringValue(cloudProvider.String())
+
+		switch cloudProvider {
+		case CloudProviderAWS:
+			if account.SourceAccountAttributes.HasAws() {
+				awsAttrs := account.SourceAccountAttributes.GetAws()
+				data.Aws = &AwsAccountConfigModel{
+					RoleArn: types.StringValue(awsAttrs.GetRoleArn()),
+				}
+				data.Role = types.StringValue(awsAttrs.GetRoleArn())
+			}
+		case CloudProviderAzure:
+			if account.SourceAccountAttributes.HasAzure() {
+				azureAttrs := account.SourceAccountAttributes.GetAzure()
+				data.Azure = &AzureAccountConfigModel{
+					TenantId:       types.StringValue(azureAttrs.GetTenantId()),
+					SubscriptionId: types.StringValue(account.GetProviderAccountId()),
+				}
+			}
+			data.Role = types.StringNull()
+		case CloudProviderGCP:
+			if account.SourceAccountAttributes.HasGcp() {
+				gcpAttrs := account.SourceAccountAttributes.GetGcp()
+				data.Gcp = &GcpAccountConfigModel{
+					ProjectId:      types.StringValue(account.GetProviderAccountId()),
+					ServiceAccount: types.StringValue(gcpAttrs.GetServiceAccount()),
+				}
+			}
+			data.Role = types.StringNull()
+		}
+
+		return &data, nil
+	}
+
+	return nil, fmt.Errorf("source account %s not found", accountId)
 }
 
 func (r *SourceAccountResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/resource_source_account.go
+++ b/internal/provider/resource_source_account.go
@@ -79,7 +79,7 @@ func (r *SourceAccountResource) Schema(ctx context.Context, req resource.SchemaR
 			"status": schema.StringAttribute{
 				MarkdownDescription: "Connection status of the source account. The provider automatically reconnects accounts that drift to `DISCONNECTED`. Possible values: `CONNECTED`, `DISCONNECTED`, `INSUFFICIENT_PERMISSIONS`.",
 				Computed:            true,
-				PlanModifiers:       []planmodifier.String{AlwaysConnected()},
+				PlanModifiers:       []planmodifier.String{ReconnectOnDisconnected()},
 			},
 			"created_at": schema.StringAttribute{
 				MarkdownDescription: "Date and time the source account was connected to the Eon project.",
@@ -89,6 +89,7 @@ func (r *SourceAccountResource) Schema(ctx context.Context, req resource.SchemaR
 			"updated_at": schema.StringAttribute{
 				MarkdownDescription: "Date and time the source account was last updated.",
 				Computed:            true,
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -339,6 +340,21 @@ func (r *SourceAccountResource) Read(ctx context.Context, req resource.ReadReque
 	if !found {
 		resp.State.RemoveResource(ctx)
 		return
+	}
+
+	// Surface account statuses the provider cannot auto-remediate so the user
+	// sees them in plan output. DISCONNECTED is handled by the plan modifier
+	// and the Update flow; anything else non-CONNECTED needs manual attention.
+	status := data.Status.ValueString()
+	if status != "" && status != "CONNECTED" && status != "DISCONNECTED" {
+		resp.Diagnostics.AddAttributeWarning(
+			path.Root("status"),
+			"Source Account Requires Manual Intervention",
+			fmt.Sprintf(
+				"Source account %s is in status %q. The provider cannot automatically remediate this state; resolve the underlying issue in the Eon console or cloud provider and re-run.",
+				data.Id.ValueString(), status,
+			),
+		)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/resource_source_account.go
+++ b/internal/provider/resource_source_account.go
@@ -89,7 +89,6 @@ func (r *SourceAccountResource) Schema(ctx context.Context, req resource.SchemaR
 			"updated_at": schema.StringAttribute{
 				MarkdownDescription: "Date and time the source account was last updated.",
 				Computed:            true,
-				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -360,6 +359,7 @@ func (r *SourceAccountResource) Update(ctx context.Context, req resource.UpdateR
 	}
 
 	accountId := state.Id.ValueString()
+	var latestAccount *externalEonSdkAPI.SourceAccount
 
 	// Step 1: Update mutable fields (name, role_arn) if changed.
 	updateReq := r.buildUpdateRequest(plan, state)
@@ -368,7 +368,7 @@ func (r *SourceAccountResource) Update(ctx context.Context, req resource.UpdateR
 			"id": accountId,
 		})
 
-		_, err := r.client.UpdateSourceAccount(ctx, accountId, *updateReq)
+		account, err := r.client.UpdateSourceAccount(ctx, accountId, *updateReq)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Update Failed",
@@ -376,6 +376,7 @@ func (r *SourceAccountResource) Update(ctx context.Context, req resource.UpdateR
 			)
 			return
 		}
+		latestAccount = account
 	}
 
 	// Step 2: Reconnect if the account is DISCONNECTED.
@@ -384,7 +385,7 @@ func (r *SourceAccountResource) Update(ctx context.Context, req resource.UpdateR
 			"id": accountId,
 		})
 
-		_, err := r.client.ReconnectSourceAccount(ctx, accountId)
+		account, err := r.client.ReconnectSourceAccount(ctx, accountId)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Reconnect Failed",
@@ -392,22 +393,28 @@ func (r *SourceAccountResource) Update(ctx context.Context, req resource.UpdateR
 			)
 			return
 		}
+		latestAccount = account
 
 		tflog.Info(ctx, "Source account reconnected", map[string]interface{}{
 			"id": accountId,
 		})
 	}
 
-	// Step 3: Read the account back from the API to sync all fields.
-	newState, err := r.readSourceAccount(ctx, accountId, plan)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Read After Update Failed",
-			fmt.Sprintf("Unable to read source account %s after update: %s", accountId, err),
-		)
+	// Step 3: Build new state from the API response, or read back if no response was returned.
+	if latestAccount == nil {
+		fetched, err := r.readSourceAccount(ctx, accountId, plan)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Read After Update Failed",
+				fmt.Sprintf("Unable to read source account %s after update: %s", accountId, err),
+			)
+			return
+		}
+		resp.Diagnostics.Append(resp.State.Set(ctx, fetched)...)
 		return
 	}
 
+	newState := r.mapAccountToState(latestAccount, plan)
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
 }
 
@@ -440,8 +447,54 @@ func (r *SourceAccountResource) buildUpdateRequest(plan, state SourceAccountReso
 	return &req
 }
 
+// mapAccountToState maps a SourceAccount API response to the Terraform resource model.
+// The plan is used to preserve fields not returned by the API (timestamps).
+func (r *SourceAccountResource) mapAccountToState(account *externalEonSdkAPI.SourceAccount, plan SourceAccountResourceModel) *SourceAccountResourceModel {
+	data := SourceAccountResourceModel{
+		Id:                types.StringValue(account.Id),
+		Name:              types.StringValue(account.GetName()),
+		Status:            types.StringValue(string(account.Status)),
+		ProviderAccountId: types.StringValue(account.GetProviderAccountId()),
+		CreatedAt:         plan.CreatedAt,
+		UpdatedAt:         types.StringValue(time.Now().Format(time.RFC3339)),
+	}
+
+	cloudProvider := CloudProvider(account.SourceAccountAttributes.GetCloudProvider())
+	data.CloudProvider = types.StringValue(cloudProvider.String())
+
+	switch cloudProvider {
+	case CloudProviderAWS:
+		if account.SourceAccountAttributes.HasAws() {
+			awsAttrs := account.SourceAccountAttributes.GetAws()
+			data.Aws = &AwsAccountConfigModel{
+				RoleArn: types.StringValue(awsAttrs.GetRoleArn()),
+			}
+			data.Role = types.StringValue(awsAttrs.GetRoleArn())
+		}
+	case CloudProviderAzure:
+		if account.SourceAccountAttributes.HasAzure() {
+			azureAttrs := account.SourceAccountAttributes.GetAzure()
+			data.Azure = &AzureAccountConfigModel{
+				TenantId:       types.StringValue(azureAttrs.GetTenantId()),
+				SubscriptionId: types.StringValue(account.GetProviderAccountId()),
+			}
+		}
+		data.Role = types.StringNull()
+	case CloudProviderGCP:
+		if account.SourceAccountAttributes.HasGcp() {
+			gcpAttrs := account.SourceAccountAttributes.GetGcp()
+			data.Gcp = &GcpAccountConfigModel{
+				ProjectId:      types.StringValue(account.GetProviderAccountId()),
+				ServiceAccount: types.StringValue(gcpAttrs.GetServiceAccount()),
+			}
+		}
+		data.Role = types.StringNull()
+	}
+
+	return &data
+}
+
 // readSourceAccount fetches a source account by ID and maps it to the resource model.
-// The plan is used to preserve user-configured values for fields not returned by the API.
 func (r *SourceAccountResource) readSourceAccount(ctx context.Context, accountId string, plan SourceAccountResourceModel) (*SourceAccountResourceModel, error) {
 	accounts, err := r.client.ListSourceAccounts(ctx)
 	if err != nil {
@@ -452,49 +505,7 @@ func (r *SourceAccountResource) readSourceAccount(ctx context.Context, accountId
 		if account.Id != accountId {
 			continue
 		}
-
-		data := SourceAccountResourceModel{
-			Id:                types.StringValue(account.Id),
-			Name:              types.StringValue(account.GetName()),
-			Status:            types.StringValue(string(account.Status)),
-			ProviderAccountId: types.StringValue(account.GetProviderAccountId()),
-			CreatedAt:         plan.CreatedAt,
-			UpdatedAt:         types.StringValue(time.Now().Format(time.RFC3339)),
-		}
-
-		cloudProvider := CloudProvider(account.SourceAccountAttributes.GetCloudProvider())
-		data.CloudProvider = types.StringValue(cloudProvider.String())
-
-		switch cloudProvider {
-		case CloudProviderAWS:
-			if account.SourceAccountAttributes.HasAws() {
-				awsAttrs := account.SourceAccountAttributes.GetAws()
-				data.Aws = &AwsAccountConfigModel{
-					RoleArn: types.StringValue(awsAttrs.GetRoleArn()),
-				}
-				data.Role = types.StringValue(awsAttrs.GetRoleArn())
-			}
-		case CloudProviderAzure:
-			if account.SourceAccountAttributes.HasAzure() {
-				azureAttrs := account.SourceAccountAttributes.GetAzure()
-				data.Azure = &AzureAccountConfigModel{
-					TenantId:       types.StringValue(azureAttrs.GetTenantId()),
-					SubscriptionId: types.StringValue(account.GetProviderAccountId()),
-				}
-			}
-			data.Role = types.StringNull()
-		case CloudProviderGCP:
-			if account.SourceAccountAttributes.HasGcp() {
-				gcpAttrs := account.SourceAccountAttributes.GetGcp()
-				data.Gcp = &GcpAccountConfigModel{
-					ProjectId:      types.StringValue(account.GetProviderAccountId()),
-					ServiceAccount: types.StringValue(gcpAttrs.GetServiceAccount()),
-				}
-			}
-			data.Role = types.StringNull()
-		}
-
-		return &data, nil
+		return r.mapAccountToState(&account, plan), nil
 	}
 
 	return nil, fmt.Errorf("source account %s not found", accountId)
@@ -641,3 +652,4 @@ func (r *SourceAccountResource) findExistingAccount(ctx context.Context, cloudPr
 
 	return nil
 }
+

--- a/internal/provider/resource_source_account.go
+++ b/internal/provider/resource_source_account.go
@@ -652,4 +652,3 @@ func (r *SourceAccountResource) findExistingAccount(ctx context.Context, cloudPr
 
 	return nil
 }
-


### PR DESCRIPTION
## Summary
- Auto-reconnect source accounts that drift to `DISCONNECTED` on `terraform apply`
- Support in-place update for `name` and `role_arn` (AWS) via new PATCH endpoint
- Read all fields from API after update/reconnect to keep state in sync
- Update client stubbed until SDK includes the new endpoint (depends on EON-9080)

## Test plan
- [ ] Unit tests pass (`make test`)
- [ ] Manual test: create source account → disconnect via UI → `terraform plan` shows drift → `terraform apply` reconnects
- [ ] Manual test: change `name` in config → `terraform apply` calls update API
- [ ] Manual test: change `role_arn` → `terraform apply` calls update API
- [ ] Verify `INSUFFICIENT_PERMISSIONS` does NOT trigger auto-reconnect
- [ ] Wire up real `UpdateSourceAccount` client once SDK is updated

## Future improvement (optional)
Add a custom plan modifier on `role_arn` that parses the ARN and triggers **replace** (instead of update) when the AWS account ID portion changes. This would catch invalid cross-account role changes at plan time with a clear Terraform message, rather than waiting for the API to reject them at apply time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)