### PR TITLE
(EON-9304) fix: upgrade eon-sdk-go to v1.116.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.4
 
 require (
-	github.com/eon-io/eon-sdk-go v1.89.0
+	github.com/eon-io/eon-sdk-go v1.116.0
 	github.com/hashicorp/terraform-plugin-docs v0.24.0
 	github.com/hashicorp/terraform-plugin-framework v1.13.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/eon-io/eon-sdk-go v1.89.0 h1:n1/B9E2CFHyNvVvis9oeV6Z9oj+pQD42Fqi6UuMN+40=
-github.com/eon-io/eon-sdk-go v1.89.0/go.mod h1:NWrS3rllESPQ7vzryT7+bHkOpNrXbXcnRtaPlv0LScw=
+github.com/eon-io/eon-sdk-go v1.116.0 h1:DG15D66lgwRdJdBfMUvVLUtrJ5VH+BnYnleLCnkH2Dc=
+github.com/eon-io/eon-sdk-go v1.116.0/go.mod h1:NWrS3rllESPQ7vzryT7+bHkOpNrXbXcnRtaPlv0LScw=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -333,7 +333,7 @@ func (c *EonClient) GetRestoreJob(ctx context.Context, jobId string) (*externalE
 		return nil, fmt.Errorf("failed to ensure valid token: %w", err)
 	}
 
-	resp, httpResp, err := c.client.JobsAPI.GetRestoreJob(ctx, jobId, c.projectID).Execute()
+	resp, httpResp, err := c.client.JobsAPI.GetRestoreJob(ctx, c.projectID, jobId).Execute()
 	if apiErr := c.handleAPIError(err, httpResp, "failed to get restore job"); apiErr != nil {
 		return nil, apiErr
 	}
@@ -376,7 +376,7 @@ func (c *EonClient) GetResourceById(ctx context.Context, resourceId string) (*ex
 		return nil, fmt.Errorf("failed to ensure valid token: %w", err)
 	}
 
-	resp, httpResp, err := c.client.ResourcesAPI.GetResource(ctx, resourceId, c.projectID).Execute()
+	resp, httpResp, err := c.client.ResourcesAPI.GetResource(ctx, c.projectID, resourceId).Execute()
 	if apiErr := c.handleAPIError(err, httpResp, "failed to get resource"); apiErr != nil {
 		return nil, apiErr
 	}
@@ -610,7 +610,7 @@ func (c *EonClient) GetSnapshot(ctx context.Context, snapshotId string) (*extern
 		return nil, fmt.Errorf("failed to ensure valid token: %w", err)
 	}
 
-	resp, httpResp, err := c.client.SnapshotsAPI.GetSnapshot(ctx, snapshotId, c.projectID).Execute()
+	resp, httpResp, err := c.client.SnapshotsAPI.GetSnapshot(ctx, c.projectID, snapshotId).Execute()
 	if apiErr := c.handleAPIError(err, httpResp, "failed to get snapshot"); apiErr != nil {
 		return nil, apiErr
 	}
@@ -689,7 +689,7 @@ func (c *EonClient) GetBackupPolicy(ctx context.Context, policyId string) (*exte
 		return nil, fmt.Errorf("failed to ensure valid token: %w", err)
 	}
 
-	resp, httpResp, err := c.client.BackupPoliciesAPI.GetBackupPolicy(ctx, policyId, c.projectID).Execute()
+	resp, httpResp, err := c.client.BackupPoliciesAPI.GetBackupPolicy(ctx, c.projectID, policyId).Execute()
 	if apiErr := c.handleAPIError(err, httpResp, "failed to get backup policy"); apiErr != nil {
 		return nil, apiErr
 	}
@@ -733,7 +733,7 @@ func (c *EonClient) UpdateBackupPolicy(ctx context.Context, policyId string, req
 		return nil, fmt.Errorf("failed to ensure valid token: %w", err)
 	}
 
-	resp, httpResp, err := c.client.BackupPoliciesAPI.UpdateBackupPolicy(ctx, policyId, c.projectID).UpdateBackupPolicyRequest(req).Execute()
+	resp, httpResp, err := c.client.BackupPoliciesAPI.UpdateBackupPolicy(ctx, c.projectID, policyId).UpdateBackupPolicyRequest(req).Execute()
 	if apiErr := c.handleAPIError(err, httpResp, "failed to update backup policy"); apiErr != nil {
 		return nil, apiErr
 	}
@@ -754,7 +754,7 @@ func (c *EonClient) DeleteBackupPolicy(ctx context.Context, policyId string) err
 		return fmt.Errorf("failed to ensure valid token: %w", err)
 	}
 
-	httpResp, err := c.client.BackupPoliciesAPI.DeleteBackupPolicy(ctx, policyId, c.projectID).Execute()
+	httpResp, err := c.client.BackupPoliciesAPI.DeleteBackupPolicy(ctx, c.projectID, policyId).Execute()
 	if apiErr := c.handleAPIError(err, httpResp, "failed to delete backup policy"); apiErr != nil {
 		return apiErr
 	}
@@ -798,7 +798,7 @@ func (c *EonClient) GetVault(ctx context.Context, vaultId string) (*externalEonS
 		return nil, fmt.Errorf("failed to ensure valid token: %w", err)
 	}
 
-	resp, httpResp, err := c.client.VaultsAPI.GetVault(ctx, vaultId, c.projectID).Execute()
+	resp, httpResp, err := c.client.VaultsAPI.GetVault(ctx, c.projectID, vaultId).Execute()
 	if apiErr := c.handleAPIError(err, httpResp, "failed to get vault"); apiErr != nil {
 		return nil, apiErr
 	}
@@ -822,7 +822,7 @@ func (c *EonClient) UpdateVault(ctx context.Context, vaultId string, req externa
 		return nil, fmt.Errorf("failed to ensure valid token: %w", err)
 	}
 
-	resp, httpResp, err := c.client.VaultsAPI.UpdateVault(ctx, vaultId, c.projectID).UpdateVaultRequest(req).Execute()
+	resp, httpResp, err := c.client.VaultsAPI.UpdateVault(ctx, c.projectID, vaultId).UpdateVaultRequest(req).Execute()
 	if apiErr := c.handleAPIError(err, httpResp, "failed to update vault"); apiErr != nil {
 		return nil, apiErr
 	}

--- a/internal/provider/data_source_restore_accounts.go
+++ b/internal/provider/data_source_restore_accounts.go
@@ -124,11 +124,7 @@ func (d *RestoreAccountsDataSource) Read(ctx context.Context, req datasource.Rea
 			UpdatedAt:         types.StringNull(),
 		}
 
-		if account.RestoreAccountAttributes.HasCloudProvider() {
-			accountModel.Provider = types.StringValue(string(account.RestoreAccountAttributes.GetCloudProvider()))
-		} else {
-			accountModel.Provider = types.StringNull()
-		}
+		accountModel.Provider = types.StringValue(string(account.RestoreAccountAttributes.GetCloudProvider()))
 
 		data.Accounts = append(data.Accounts, accountModel)
 	}

--- a/internal/provider/resource_restore_account.go
+++ b/internal/provider/resource_restore_account.go
@@ -244,9 +244,7 @@ func (r *RestoreAccountResource) Create(ctx context.Context, req resource.Create
 	data.Status = types.StringValue(string(account.Status))
 	data.ProviderAccountId = types.StringValue(account.GetProviderAccountId())
 
-	if account.RestoreAccountAttributes.HasCloudProvider() {
-		data.CloudProvider = types.StringValue(string(account.RestoreAccountAttributes.GetCloudProvider()))
-	}
+	data.CloudProvider = types.StringValue(string(account.RestoreAccountAttributes.GetCloudProvider()))
 
 	data.CreatedAt = types.StringValue(time.Now().Format(time.RFC3339))
 	data.UpdatedAt = types.StringValue(time.Now().Format(time.RFC3339))
@@ -292,11 +290,8 @@ func (r *RestoreAccountResource) Read(ctx context.Context, req resource.ReadRequ
 			data.Status = types.StringValue(string(account.Status))
 			data.ProviderAccountId = types.StringValue(account.GetProviderAccountId())
 
-			var cloudProvider CloudProvider
-			if account.RestoreAccountAttributes.HasCloudProvider() {
-				cloudProvider = CloudProvider(account.RestoreAccountAttributes.GetCloudProvider())
-				data.CloudProvider = types.StringValue(cloudProvider.String())
-			}
+			cloudProvider := CloudProvider(account.RestoreAccountAttributes.GetCloudProvider())
+			data.CloudProvider = types.StringValue(cloudProvider.String())
 
 			// Populate cloud-specific blocks from API response
 			switch cloudProvider {
@@ -414,11 +409,8 @@ func (r *RestoreAccountResource) ImportState(ctx context.Context, req resource.I
 			data.Status = types.StringValue(string(account.Status))
 			data.ProviderAccountId = types.StringValue(account.GetProviderAccountId())
 
-			var cloudProvider CloudProvider
-			if account.RestoreAccountAttributes.HasCloudProvider() {
-				cloudProvider = CloudProvider(account.RestoreAccountAttributes.GetCloudProvider())
-				data.CloudProvider = types.StringValue(cloudProvider.String())
-			}
+			cloudProvider := CloudProvider(account.RestoreAccountAttributes.GetCloudProvider())
+			data.CloudProvider = types.StringValue(cloudProvider.String())
 
 			// Populate cloud-specific blocks from API response
 			switch cloudProvider {

--- a/internal/provider/restore_job_resource.go
+++ b/internal/provider/restore_job_resource.go
@@ -1474,10 +1474,11 @@ func (r *RestoreJobResource) createGcpCloudSqlRestore(ctx context.Context, data 
 		sqlTarget.Labels = &sqlLabels
 	}
 
+	nullableSqlTarget := externalEonSdkAPI.NewNullableGcpCloudSqlTarget(sqlTarget)
 	apiReq := externalEonSdkAPI.RestoreGcpCloudSqlRequest{
 		RestoreAccountId: data.RestoreAccountId.ValueString(),
 		Destination: externalEonSdkAPI.GcpCloudSqlRestoreDestination{
-			GcpCloudSql: sqlTarget,
+			GcpCloudSql: *nullableSqlTarget,
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Bumps `eon-sdk-go` from v1.89.0 to v1.116.0 to align with API changes from eon-io/eon-service#25866 (`projectId` moved to first path parameter)
- Fixes 8 SDK call sites where argument order changed (`projectId` now first)
- Adapts to `CloudProvider` becoming a required field (removed `HasCloudProvider()` checks)
- Wraps `GcpCloudSqlTarget` with `NewNullableGcpCloudSqlTarget()` for updated nullable type

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Run acceptance tests against dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://eon.devinenterprise.com/review/eon-io/terraform-provider-eon/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
