### PR TITLE
feat: upgrade SDK to v1.117.0 and add restore_destination_limits to eon_role

### DIFF
--- a/docs/data-sources/roles.md
+++ b/docs/data-sources/roles.md
@@ -111,6 +111,10 @@ output "role_ids_by_name" {
 <a id="nestedatt--roles"></a>
 ### Nested Schema for `roles`
 
+Optional:
+
+- `restore_destination_limits` (Attributes) Optional limits on which restore destination accounts are allowed or denied for this role. (see [below for nested schema](#nestedatt--roles--restore_destination_limits))
+
 Read-Only:
 
 - `access_conditions` (Attributes List) Optional list of access conditions that can be referenced by permission_grants to restrict the scope of permissions. (see [below for nested schema](#nestedatt--roles--access_conditions))
@@ -118,6 +122,15 @@ Read-Only:
 - `is_built_in_role` (Boolean) Whether the role is a built-in role provided by Eon (true) or a custom role (false). Built-in roles cannot be modified or deleted.
 - `name` (String) Display name of the role.
 - `permission_grants` (Attributes List) List of permissions granted by the role. (see [below for nested schema](#nestedatt--roles--permission_grants))
+
+<a id="nestedatt--roles--restore_destination_limits"></a>
+### Nested Schema for `roles.restore_destination_limits`
+
+Read-Only:
+
+- `effect` (String) Effect of the limit (e.g. ALLOW, DENY).
+- `restore_account_provider_ids` (List of String) List of restore account provider IDs to match against.
+
 
 <a id="nestedatt--roles--access_conditions"></a>
 ### Nested Schema for `roles.access_conditions`

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -530,6 +530,8 @@ Required:
 - `vpcs` (List of String) List of VPCs
 
 
+
+
 <a id="nestedatt--restore_destination_limits"></a>
 ### Nested Schema for `restore_destination_limits`
 
@@ -537,5 +539,3 @@ Required:
 
 - `effect` (String) Effect of the limit (e.g. ALLOW, DENY).
 - `restore_account_provider_ids` (List of String) List of restore account provider IDs to match against.
-
-

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -140,6 +140,22 @@ resource "eon_role" "prod_ec2_only" {
   ]
 }
 
+# Example: Role with restore_destination_limits (restrict which restore accounts can be used)
+resource "eon_role" "restricted_restores" {
+  name = "Restricted Restore Operator (Custom)"
+
+  permission_grants = [
+    { permission = "restores.create" },
+    { permission = "inventory.view" },
+  ]
+
+  # Allow restores only to specific restore account providers
+  restore_destination_limits = {
+    effect                       = "ALLOW"
+    restore_account_provider_ids = ["account-provider-id-1", "account-provider-id-2"]
+  }
+}
+
 # For built-in roles in eon_idp_group, use the eon_builtin_roles data source (stable keys), not lookup by display name.
 ```
 
@@ -154,6 +170,7 @@ resource "eon_role" "prod_ec2_only" {
 ### Optional
 
 - `access_conditions` (Attributes List) Optional list of access conditions that can be referenced by permission_grants to restrict the scope of permissions. (see [below for nested schema](#nestedatt--access_conditions))
+- `restore_destination_limits` (Attributes) Optional limits on which restore destination accounts are allowed or denied for this role. (see [below for nested schema](#nestedatt--restore_destination_limits))
 
 ### Read-Only
 
@@ -511,3 +528,12 @@ Required:
 
 - `operator` (String) Operator: IN or NOT_IN
 - `vpcs` (List of String) List of VPCs
+
+
+<a id="nestedatt--restore_destination_limits"></a>
+### Nested Schema for `restore_destination_limits`
+
+Required:
+
+- `effect` (String) Effect of the limit (e.g. ALLOW, DENY).
+- `restore_account_provider_ids` (List of String) List of restore account provider IDs to match against.

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -537,3 +537,5 @@ Required:
 
 - `effect` (String) Effect of the limit (e.g. ALLOW, DENY).
 - `restore_account_provider_ids` (List of String) List of restore account provider IDs to match against.
+
+

--- a/examples/resources/eon_role/resource.tf
+++ b/examples/resources/eon_role/resource.tf
@@ -125,4 +125,20 @@ resource "eon_role" "prod_ec2_only" {
   ]
 }
 
+# Example: Role with restore_destination_limits (restrict which restore accounts can be used)
+resource "eon_role" "restricted_restores" {
+  name = "Restricted Restore Operator (Custom)"
+
+  permission_grants = [
+    { permission = "restores.create" },
+    { permission = "inventory.view" },
+  ]
+
+  # Allow restores only to specific restore account providers
+  restore_destination_limits = {
+    effect                       = "ALLOW"
+    restore_account_provider_ids = ["account-provider-id-1", "account-provider-id-2"]
+  }
+}
+
 # For built-in roles in eon_idp_group, use the eon_builtin_roles data source (stable keys), not lookup by display name.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.4
 
 require (
-	github.com/eon-io/eon-sdk-go v1.116.0
+	github.com/eon-io/eon-sdk-go v1.117.0
 	github.com/hashicorp/terraform-plugin-docs v0.24.0
 	github.com/hashicorp/terraform-plugin-framework v1.13.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/eon-io/eon-sdk-go v1.116.0 h1:DG15D66lgwRdJdBfMUvVLUtrJ5VH+BnYnleLCnkH2Dc=
-github.com/eon-io/eon-sdk-go v1.116.0/go.mod h1:NWrS3rllESPQ7vzryT7+bHkOpNrXbXcnRtaPlv0LScw=
+github.com/eon-io/eon-sdk-go v1.117.0 h1:OI/8uxdUc1rAoXg5scTLfvkIl7SioD5eLCSnbF9gW1s=
+github.com/eon-io/eon-sdk-go v1.117.0/go.mod h1:NWrS3rllESPQ7vzryT7+bHkOpNrXbXcnRtaPlv0LScw=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=

--- a/internal/client/mock_client.go
+++ b/internal/client/mock_client.go
@@ -402,9 +402,7 @@ func (m *MockEonClient) UpdateRole(ctx context.Context, roleId string, req exter
 	}
 	r.Name = req.GetName()
 	r.PermissionGrants = permissionGrantInputToGrant(req.GetPermissionGrants())
-	if req.AccessConditions != nil {
-		r.AccessConditions = req.AccessConditions
-	}
+	r.AccessConditions = req.AccessConditions
 	if req.HasRestoreDestinationLimits() {
 		rdl := req.GetRestoreDestinationLimits()
 		r.RestoreDestinationLimits = *externalEonSdkAPI.NewNullableRestoreDestinationLimits(&rdl)

--- a/internal/client/mock_client.go
+++ b/internal/client/mock_client.go
@@ -374,6 +374,10 @@ func (m *MockEonClient) CreateRole(ctx context.Context, req externalEonSdkAPI.Cr
 	if req.AccessConditions != nil {
 		role.AccessConditions = req.AccessConditions
 	}
+	if req.HasRestoreDestinationLimits() {
+		rdl := req.GetRestoreDestinationLimits()
+		role.RestoreDestinationLimits = *externalEonSdkAPI.NewNullableRestoreDestinationLimits(&rdl)
+	}
 	m.Roles[id] = role
 	return role, nil
 }
@@ -400,6 +404,12 @@ func (m *MockEonClient) UpdateRole(ctx context.Context, roleId string, req exter
 	r.PermissionGrants = permissionGrantInputToGrant(req.GetPermissionGrants())
 	if req.AccessConditions != nil {
 		r.AccessConditions = req.AccessConditions
+	}
+	if req.HasRestoreDestinationLimits() {
+		rdl := req.GetRestoreDestinationLimits()
+		r.RestoreDestinationLimits = *externalEonSdkAPI.NewNullableRestoreDestinationLimits(&rdl)
+	} else {
+		r.RestoreDestinationLimits.Unset()
 	}
 	m.Roles[roleId] = r
 	return r, nil

--- a/internal/provider/data_source_roles.go
+++ b/internal/provider/data_source_roles.go
@@ -187,9 +187,12 @@ func (d *RolesDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		rdlVal := types.ObjectNull(restoreDestinationLimitsAttrTypes)
 		if r.HasRestoreDestinationLimits() {
 			rdl := r.GetRestoreDestinationLimits()
-			if v, d := flattenRestoreDestinationLimits(rdl); !d.HasError() {
-				rdlVal = v
+			v, d := flattenRestoreDestinationLimits(rdl)
+			if d.HasError() {
+				resp.Diagnostics.Append(d...)
+				return
 			}
+			rdlVal = v
 		}
 
 		data.Roles = append(data.Roles, RoleModel{

--- a/internal/provider/data_source_roles.go
+++ b/internal/provider/data_source_roles.go
@@ -28,11 +28,11 @@ type RolesDataSourceModel struct {
 }
 
 type RoleModel struct {
-	Id                      types.String `tfsdk:"id"`
-	Name                    types.String `tfsdk:"name"`
-	IsBuiltInRole           types.Bool   `tfsdk:"is_built_in_role"`
-	PermissionGrants        types.List   `tfsdk:"permission_grants"`
-	AccessConditions        types.List   `tfsdk:"access_conditions"`
+	Id                       types.String `tfsdk:"id"`
+	Name                     types.String `tfsdk:"name"`
+	IsBuiltInRole            types.Bool   `tfsdk:"is_built_in_role"`
+	PermissionGrants         types.List   `tfsdk:"permission_grants"`
+	AccessConditions         types.List   `tfsdk:"access_conditions"`
 	RestoreDestinationLimits types.Object `tfsdk:"restore_destination_limits"`
 }
 

--- a/internal/provider/data_source_roles.go
+++ b/internal/provider/data_source_roles.go
@@ -28,11 +28,12 @@ type RolesDataSourceModel struct {
 }
 
 type RoleModel struct {
-	Id               types.String `tfsdk:"id"`
-	Name             types.String `tfsdk:"name"`
-	IsBuiltInRole    types.Bool   `tfsdk:"is_built_in_role"`
-	PermissionGrants types.List   `tfsdk:"permission_grants"`
-	AccessConditions types.List   `tfsdk:"access_conditions"`
+	Id                      types.String `tfsdk:"id"`
+	Name                    types.String `tfsdk:"name"`
+	IsBuiltInRole           types.Bool   `tfsdk:"is_built_in_role"`
+	PermissionGrants        types.List   `tfsdk:"permission_grants"`
+	AccessConditions        types.List   `tfsdk:"access_conditions"`
+	RestoreDestinationLimits types.Object `tfsdk:"restore_destination_limits"`
 }
 
 type PermissionGrantModel struct {
@@ -109,6 +110,22 @@ func (d *RolesDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 								},
 							},
 						},
+						"restore_destination_limits": schema.SingleNestedAttribute{
+							MarkdownDescription: "Optional limits on which restore destination accounts are allowed or denied for this role.",
+							Computed:            true,
+							Optional:            true,
+							Attributes: map[string]schema.Attribute{
+								"effect": schema.StringAttribute{
+									MarkdownDescription: "Effect of the limit (e.g. ALLOW, DENY).",
+									Computed:            true,
+								},
+								"restore_account_provider_ids": schema.ListAttribute{
+									MarkdownDescription: "List of restore account provider IDs to match against.",
+									Computed:            true,
+									ElementType:         types.StringType,
+								},
+							},
+						},
 					},
 				},
 			},
@@ -167,12 +184,21 @@ func (d *RolesDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 			}
 		}
 
+		rdlVal := types.ObjectNull(restoreDestinationLimitsAttrTypes)
+		if r.HasRestoreDestinationLimits() {
+			rdl := r.GetRestoreDestinationLimits()
+			if v, d := flattenRestoreDestinationLimits(rdl); !d.HasError() {
+				rdlVal = v
+			}
+		}
+
 		data.Roles = append(data.Roles, RoleModel{
-			Id:               types.StringValue(r.GetId()),
-			Name:             types.StringValue(r.GetName()),
-			IsBuiltInRole:    types.BoolValue(r.GetIsBuiltInRole()),
-			PermissionGrants: permGrantsVal,
-			AccessConditions: accessCondsVal,
+			Id:                       types.StringValue(r.GetId()),
+			Name:                     types.StringValue(r.GetName()),
+			IsBuiltInRole:            types.BoolValue(r.GetIsBuiltInRole()),
+			PermissionGrants:         permGrantsVal,
+			AccessConditions:         accessCondsVal,
+			RestoreDestinationLimits: rdlVal,
 		})
 	}
 

--- a/internal/provider/resource_role.go
+++ b/internal/provider/resource_role.go
@@ -28,10 +28,10 @@ type RoleResource struct {
 }
 
 type RoleResourceModel struct {
-	Id                      types.String `tfsdk:"id"`
-	Name                    types.String `tfsdk:"name"`
-	PermissionGrants        types.List   `tfsdk:"permission_grants"`
-	AccessConditions        types.List   `tfsdk:"access_conditions"`
+	Id                       types.String `tfsdk:"id"`
+	Name                     types.String `tfsdk:"name"`
+	PermissionGrants         types.List   `tfsdk:"permission_grants"`
+	AccessConditions         types.List   `tfsdk:"access_conditions"`
 	RestoreDestinationLimits types.Object `tfsdk:"restore_destination_limits"`
 }
 

--- a/internal/provider/resource_role.go
+++ b/internal/provider/resource_role.go
@@ -238,6 +238,8 @@ func (r *RoleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		if rdl != nil {
 			updateReq.SetRestoreDestinationLimits(*rdl)
 		}
+	} else {
+		updateReq.SetRestoreDestinationLimitsNil()
 	}
 
 	tflog.Debug(ctx, "Updating role", map[string]interface{}{

--- a/internal/provider/resource_role.go
+++ b/internal/provider/resource_role.go
@@ -28,10 +28,11 @@ type RoleResource struct {
 }
 
 type RoleResourceModel struct {
-	Id               types.String `tfsdk:"id"`
-	Name             types.String `tfsdk:"name"`
-	PermissionGrants types.List   `tfsdk:"permission_grants"`
-	AccessConditions types.List   `tfsdk:"access_conditions"`
+	Id                      types.String `tfsdk:"id"`
+	Name                    types.String `tfsdk:"name"`
+	PermissionGrants        types.List   `tfsdk:"permission_grants"`
+	AccessConditions        types.List   `tfsdk:"access_conditions"`
+	RestoreDestinationLimits types.Object `tfsdk:"restore_destination_limits"`
 }
 
 type RolePermissionGrantModel struct {
@@ -99,6 +100,21 @@ func (r *RoleResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 					},
 				},
 			},
+			"restore_destination_limits": schema.SingleNestedAttribute{
+				MarkdownDescription: "Optional limits on which restore destination accounts are allowed or denied for this role.",
+				Optional:            true,
+				Attributes: map[string]schema.Attribute{
+					"effect": schema.StringAttribute{
+						MarkdownDescription: "Effect of the limit (e.g. ALLOW, DENY).",
+						Required:            true,
+					},
+					"restore_account_provider_ids": schema.ListAttribute{
+						MarkdownDescription: "List of restore account provider IDs to match against.",
+						Required:            true,
+						ElementType:         types.StringType,
+					},
+				},
+			},
 		},
 	}
 }
@@ -143,6 +159,17 @@ func (r *RoleResource) Create(ctx context.Context, req resource.CreateRequest, r
 			return
 		}
 		createReq.AccessConditions = accessConds
+	}
+
+	if !data.RestoreDestinationLimits.IsNull() && !data.RestoreDestinationLimits.IsUnknown() {
+		rdl, diags := restoreDestinationLimitsToSDK(ctx, data.RestoreDestinationLimits)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if rdl != nil {
+			createReq.SetRestoreDestinationLimits(*rdl)
+		}
 	}
 
 	tflog.Debug(ctx, "Creating role", map[string]interface{}{
@@ -202,6 +229,17 @@ func (r *RoleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		updateReq.AccessConditions = accessConds
 	}
 
+	if !plan.RestoreDestinationLimits.IsNull() && !plan.RestoreDestinationLimits.IsUnknown() {
+		rdl, diags := restoreDestinationLimitsToSDK(ctx, plan.RestoreDestinationLimits)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if rdl != nil {
+			updateReq.SetRestoreDestinationLimits(*rdl)
+		}
+	}
+
 	tflog.Debug(ctx, "Updating role", map[string]interface{}{
 		"id": plan.Id.ValueString(),
 	})
@@ -257,6 +295,16 @@ func (r *RoleResource) ImportState(ctx context.Context, req resource.ImportState
 	} else if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 	}
+
+	if role.HasRestoreDestinationLimits() {
+		rdl := role.GetRestoreDestinationLimits()
+		rdlVal, d := flattenRestoreDestinationLimits(rdl)
+		if d.HasError() {
+			resp.Diagnostics.Append(d...)
+		} else {
+			resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("restore_destination_limits"), rdlVal)...)
+		}
+	}
 }
 
 func (r *RoleResource) setModelFromRole(ctx context.Context, data *RoleResourceModel, role *externalEonSdkAPI.Role) {
@@ -270,6 +318,15 @@ func (r *RoleResource) setModelFromRole(ctx context.Context, data *RoleResourceM
 	accessCondsVal, diags := flattenRoleAccessConditions(ctx, role.GetAccessConditions())
 	if !diags.HasError() {
 		data.AccessConditions = accessCondsVal
+	}
+	if role.HasRestoreDestinationLimits() {
+		rdl := role.GetRestoreDestinationLimits()
+		rdlVal, d := flattenRestoreDestinationLimits(rdl)
+		if !d.HasError() {
+			data.RestoreDestinationLimits = rdlVal
+		}
+	} else {
+		data.RestoreDestinationLimits = types.ObjectNull(restoreDestinationLimitsAttrTypes)
 	}
 }
 

--- a/internal/provider/resource_role_test.go
+++ b/internal/provider/resource_role_test.go
@@ -6,7 +6,10 @@ import (
 
 	externalEonSdkAPI "github.com/eon-io/eon-sdk-go"
 	"github.com/eon-io/terraform-provider-eon/internal/client"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRoleResource_Unit(t *testing.T) {
@@ -117,4 +120,115 @@ func TestRoleResource_DeleteWithMockClient(t *testing.T) {
 	assert.NoError(t, err)
 	_, exists := mockClient.Roles["role-1"]
 	assert.False(t, exists)
+}
+
+func TestRoleResource_CreateWithRestoreDestinationLimits(t *testing.T) {
+	t.Parallel()
+
+	mockClient := client.NewMockEonClient()
+
+	permGrants := []externalEonSdkAPI.PermissionGrantInput{
+		*externalEonSdkAPI.NewPermissionGrantInput(externalEonSdkAPI.PermissionType("restores.create")),
+	}
+
+	req := externalEonSdkAPI.NewCreateRoleRequest("Restore Operator", permGrants)
+	rdl := externalEonSdkAPI.NewRestoreDestinationLimits(
+		externalEonSdkAPI.AccessConditionEffect("ALLOW"),
+		[]string{"account-provider-1", "account-provider-2"},
+	)
+	req.SetRestoreDestinationLimits(*rdl)
+
+	role, err := mockClient.CreateRole(context.Background(), *req)
+
+	require.NoError(t, err)
+	require.NotNil(t, role)
+	assert.Equal(t, "Restore Operator", role.Name)
+	assert.True(t, role.HasRestoreDestinationLimits())
+	stored := role.GetRestoreDestinationLimits()
+	assert.Equal(t, externalEonSdkAPI.AccessConditionEffect("ALLOW"), stored.GetEffect())
+	assert.Equal(t, []string{"account-provider-1", "account-provider-2"}, stored.GetRestoreAccountProviderIds())
+}
+
+func TestRoleResource_UpdateWithRestoreDestinationLimits(t *testing.T) {
+	t.Parallel()
+
+	mockClient := client.NewMockEonClient()
+	mockClient.Roles["role-1"] = &externalEonSdkAPI.Role{
+		Id:            "role-1",
+		Name:          "Old Name",
+		IsBuiltInRole: false,
+	}
+
+	permGrants := []externalEonSdkAPI.PermissionGrantInput{
+		*externalEonSdkAPI.NewPermissionGrantInput(externalEonSdkAPI.PermissionType("restores.create")),
+	}
+	req := externalEonSdkAPI.NewUpdateRoleRequest("New Name", permGrants)
+	rdl := externalEonSdkAPI.NewRestoreDestinationLimits(
+		externalEonSdkAPI.AccessConditionEffect("DENY"),
+		[]string{"restricted-account"},
+	)
+	req.SetRestoreDestinationLimits(*rdl)
+
+	role, err := mockClient.UpdateRole(context.Background(), "role-1", *req)
+
+	require.NoError(t, err)
+	require.NotNil(t, role)
+	assert.Equal(t, "New Name", role.Name)
+	assert.True(t, role.HasRestoreDestinationLimits())
+	stored := role.GetRestoreDestinationLimits()
+	assert.Equal(t, externalEonSdkAPI.AccessConditionEffect("DENY"), stored.GetEffect())
+	assert.Equal(t, []string{"restricted-account"}, stored.GetRestoreAccountProviderIds())
+}
+
+func TestFlattenRestoreDestinationLimits(t *testing.T) {
+	t.Parallel()
+
+	rdl := *externalEonSdkAPI.NewRestoreDestinationLimits(
+		externalEonSdkAPI.AccessConditionEffect("ALLOW"),
+		[]string{"account-1", "account-2"},
+	)
+
+	obj, diags := flattenRestoreDestinationLimits(rdl)
+
+	require.False(t, diags.HasError())
+	require.False(t, obj.IsNull())
+
+	attrs := obj.Attributes()
+	assert.Equal(t, types.StringValue("ALLOW"), attrs["effect"])
+
+	idList := attrs["restore_account_provider_ids"].(types.List)
+	var ids []string
+	d2 := idList.ElementsAs(context.Background(), &ids, false)
+	require.False(t, d2.HasError())
+	assert.Equal(t, []string{"account-1", "account-2"}, ids)
+}
+
+func TestRestoreDestinationLimitsToSDK(t *testing.T) {
+	t.Parallel()
+
+	idList, _ := types.ListValue(types.StringType, []attr.Value{
+		types.StringValue("prov-1"),
+		types.StringValue("prov-2"),
+	})
+	obj, _ := types.ObjectValue(restoreDestinationLimitsAttrTypes, map[string]attr.Value{
+		"effect":                       types.StringValue("DENY"),
+		"restore_account_provider_ids": idList,
+	})
+
+	rdl, diags := restoreDestinationLimitsToSDK(context.Background(), obj)
+
+	require.False(t, diags.HasError())
+	require.NotNil(t, rdl)
+	assert.Equal(t, externalEonSdkAPI.AccessConditionEffect("DENY"), rdl.GetEffect())
+	assert.Equal(t, []string{"prov-1", "prov-2"}, rdl.GetRestoreAccountProviderIds())
+}
+
+func TestRestoreDestinationLimitsToSDK_Null(t *testing.T) {
+	t.Parallel()
+
+	obj := types.ObjectNull(restoreDestinationLimitsAttrTypes)
+	rdl, diags := restoreDestinationLimitsToSDK(context.Background(), obj)
+
+	require.False(t, diags.HasError())
+	assert.Nil(t, rdl)
 }

--- a/internal/provider/role_access_condition.go
+++ b/internal/provider/role_access_condition.go
@@ -614,6 +614,43 @@ func roleResourceIdConditionToSDK(ctx context.Context, obj types.Object) (*exter
 	return externalEonSdkAPI.NewResourceIdCondition(op, list), nil
 }
 
+// restoreDestinationLimitsAttrTypes is the attr type map for restore_destination_limits.
+var restoreDestinationLimitsAttrTypes = map[string]attr.Type{
+	"effect":                       types.StringType,
+	"restore_account_provider_ids": types.ListType{ElemType: types.StringType},
+}
+
+// restoreDestinationLimitsToSDK converts a Terraform restore_destination_limits object to the SDK type.
+func restoreDestinationLimitsToSDK(ctx context.Context, obj types.Object) (*externalEonSdkAPI.RestoreDestinationLimits, diag.Diagnostics) {
+	if obj.IsNull() || obj.IsUnknown() {
+		return nil, nil
+	}
+	attrs := obj.Attributes()
+	effect := externalEonSdkAPI.AccessConditionEffect(attrs["effect"].(types.String).ValueString())
+	var ids []string
+	if d := attrs["restore_account_provider_ids"].(types.List).ElementsAs(ctx, &ids, false); d.HasError() {
+		return nil, d
+	}
+	return externalEonSdkAPI.NewRestoreDestinationLimits(effect, ids), nil
+}
+
+// flattenRestoreDestinationLimits converts an SDK RestoreDestinationLimits to a Terraform types.Object.
+func flattenRestoreDestinationLimits(rdl externalEonSdkAPI.RestoreDestinationLimits) (types.Object, diag.Diagnostics) {
+	ids := rdl.GetRestoreAccountProviderIds()
+	idVals := make([]attr.Value, len(ids))
+	for i, id := range ids {
+		idVals[i] = types.StringValue(id)
+	}
+	idList, d := types.ListValue(types.StringType, idVals)
+	if d.HasError() {
+		return types.ObjectNull(restoreDestinationLimitsAttrTypes), d
+	}
+	return types.ObjectValue(restoreDestinationLimitsAttrTypes, map[string]attr.Value{
+		"effect":                       types.StringValue(string(rdl.GetEffect())),
+		"restore_account_provider_ids": idList,
+	})
+}
+
 // roleAccessConditionAttrTypes is the attr type map for one access condition (id, effect, expression).
 var roleAccessConditionAttrTypes = map[string]attr.Type{
 	"id":         types.StringType,


### PR DESCRIPTION
## Summary

- Upgrades `eon-sdk-go` from v1.116.0 → v1.117.0, which adds `RestoreDestinationLimits` to `Role`, `CreateRoleRequest`, and `UpdateRoleRequest`
- Adds `restore_destination_limits` optional block to the `eon_role` resource and `eon_roles` data source
- The new block has two fields: `effect` (e.g. `ALLOW`, `DENY`) and `restore_account_provider_ids` (list of restore account provider IDs to match against)

## What changed

| File | Change |
|------|--------|
| `go.mod` / `go.sum` | SDK bumped to v1.117.0 |
| `internal/provider/role_access_condition.go` | Added `restoreDestinationLimitsAttrTypes`, `restoreDestinationLimitsToSDK()`, and `flattenRestoreDestinationLimits()` helpers |
| `internal/provider/resource_role.go` | Added `RestoreDestinationLimits` to model, schema, Create, Update, `setModelFromRole`, and ImportState |
| `internal/provider/data_source_roles.go` | Added `RestoreDestinationLimits` to `RoleModel`, schema, and Read |
| `internal/client/mock_client.go` | CreateRole and UpdateRole now persist `RestoreDestinationLimits` |
| `internal/provider/resource_role_test.go` | 5 new tests: create/update with limits, flatten, to-SDK, and null case |
| `examples/resources/eon_role/resource.tf` | New example with `restore_destination_limits` |
| `docs/resources/role.md` | Updated schema docs and example |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/...` passes (all existing + 5 new tests)
- [x] New tests cover: create with limits, update with limits, flatten SDK→TF, convert TF→SDK, null input

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://eon.devinenterprise.com/review/eon-io/terraform-provider-eon/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
