### PR TITLE
chore: bump eon-sdk-go to v1.118.0 and use GetSourceAccount

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.4
 
 require (
-	github.com/eon-io/eon-sdk-go v1.117.0
+	github.com/eon-io/eon-sdk-go v1.118.0
 	github.com/hashicorp/terraform-plugin-docs v0.24.0
 	github.com/hashicorp/terraform-plugin-framework v1.13.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/eon-io/eon-sdk-go v1.117.0 h1:OI/8uxdUc1rAoXg5scTLfvkIl7SioD5eLCSnbF9gW1s=
-github.com/eon-io/eon-sdk-go v1.117.0/go.mod h1:NWrS3rllESPQ7vzryT7+bHkOpNrXbXcnRtaPlv0LScw=
+github.com/eon-io/eon-sdk-go v1.118.0 h1:1mM90i4bCqAHaL47YP1UGDYQUlB4aNcKqeTcdS8CuFw=
+github.com/eon-io/eon-sdk-go v1.118.0/go.mod h1:NWrS3rllESPQ7vzryT7+bHkOpNrXbXcnRtaPlv0LScw=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -64,6 +64,32 @@ func (c *EonClient) handleAPIError(err error, httpResp *http.Response, baseError
 	return nil
 }
 
+// GetSourceAccount retrieves a source account by ID via
+// GET /v1/projects/{projectId}/source-accounts/{accountId}.
+// Returns an *APIError with StatusCode 404 when the account does not exist.
+func (c *EonClient) GetSourceAccount(ctx context.Context, accountId string) (*externalEonSdkAPI.SourceAccount, error) {
+	if err := c.tokenRefresher.EnsureValidToken(); err != nil {
+		return nil, fmt.Errorf("failed to ensure valid token: %w", err)
+	}
+
+	resp, httpResp, err := c.client.AccountsAPI.GetSourceAccount(ctx, c.projectID, accountId).Execute()
+	if apiErr := c.handleAPIError(err, httpResp, "failed to get source account"); apiErr != nil {
+		return nil, apiErr
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(httpResp.Body)
+		return nil, &APIError{
+			StatusCode: httpResp.StatusCode,
+			Message:    string(body),
+		}
+	}
+
+	account := resp.GetSourceAccount()
+	return &account, nil
+}
+
 // ListSourceAccounts retrieves all source accounts for the project.
 // It paginates through all pages to return the complete list.
 func (c *EonClient) ListSourceAccounts(ctx context.Context) ([]externalEonSdkAPI.SourceAccount, error) {

--- a/internal/provider/resource_source_account.go
+++ b/internal/provider/resource_source_account.go
@@ -271,75 +271,67 @@ func (r *SourceAccountResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	accounts, err := r.client.ListSourceAccounts(ctx)
+	account, err := r.client.GetSourceAccount(ctx, data.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read source accounts: %s", err))
-		return
-	}
-
-	var found bool
-	for _, account := range accounts {
-		if account.Id == data.Id.ValueString() {
-			found = true
-			data.Name = types.StringValue(account.GetName())
-			data.Status = types.StringValue(string(account.Status))
-			data.ProviderAccountId = types.StringValue(account.GetProviderAccountId())
-
-			cloudProvider := CloudProvider(account.SourceAccountAttributes.GetCloudProvider())
-			data.CloudProvider = types.StringValue(cloudProvider.String())
-
-			// Populate cloud-specific blocks from API response
-			switch cloudProvider {
-			case CloudProviderAWS:
-				if account.SourceAccountAttributes.HasAws() {
-					awsAttrs := account.SourceAccountAttributes.GetAws()
-					data.Aws = &AwsAccountConfigModel{
-						RoleArn: types.StringValue(awsAttrs.GetRoleArn()),
-					}
-					// Also populate deprecated role field for backward compatibility
-					data.Role = types.StringValue(awsAttrs.GetRoleArn())
-				}
-				data.Azure = nil
-				data.Gcp = nil
-			case CloudProviderAzure:
-				if account.SourceAccountAttributes.HasAzure() {
-					azureAttrs := account.SourceAccountAttributes.GetAzure()
-					data.Azure = &AzureAccountConfigModel{
-						TenantId:       types.StringValue(azureAttrs.GetTenantId()),
-						SubscriptionId: types.StringValue(account.GetProviderAccountId()), // subscription_id is the provider_account_id
-					}
-					// ResourceGroupName is not returned in the output model for source accounts
-				}
-				data.Aws = nil
-				data.Gcp = nil
-				data.Role = types.StringNull()
-			case CloudProviderGCP:
-				if account.SourceAccountAttributes.HasGcp() {
-					gcpAttrs := account.SourceAccountAttributes.GetGcp()
-					data.Gcp = &GcpAccountConfigModel{
-						ProjectId:      types.StringValue(account.GetProviderAccountId()), // project_id is the provider_account_id
-						ServiceAccount: types.StringValue(gcpAttrs.GetServiceAccount()),
-					}
-				}
-				data.Aws = nil
-				data.Azure = nil
-				data.Role = types.StringNull()
-			}
-
-			if data.CreatedAt.IsNull() || data.CreatedAt.IsUnknown() {
-				data.CreatedAt = types.StringValue(time.Now().Format(time.RFC3339))
-			}
-			if data.UpdatedAt.IsNull() || data.UpdatedAt.IsUnknown() {
-				data.UpdatedAt = types.StringValue(time.Now().Format(time.RFC3339))
-			}
-
-			break
+		var apiErr *client.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == 404 {
+			resp.State.RemoveResource(ctx)
+			return
 		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read source account: %s", err))
+		return
 	}
 
-	if !found {
-		resp.State.RemoveResource(ctx)
-		return
+	data.Name = types.StringValue(account.GetName())
+	data.Status = types.StringValue(string(account.Status))
+	data.ProviderAccountId = types.StringValue(account.GetProviderAccountId())
+
+	cloudProvider := CloudProvider(account.SourceAccountAttributes.GetCloudProvider())
+	data.CloudProvider = types.StringValue(cloudProvider.String())
+
+	// Populate cloud-specific blocks from API response
+	switch cloudProvider {
+	case CloudProviderAWS:
+		if account.SourceAccountAttributes.HasAws() {
+			awsAttrs := account.SourceAccountAttributes.GetAws()
+			data.Aws = &AwsAccountConfigModel{
+				RoleArn: types.StringValue(awsAttrs.GetRoleArn()),
+			}
+			// Also populate deprecated role field for backward compatibility
+			data.Role = types.StringValue(awsAttrs.GetRoleArn())
+		}
+		data.Azure = nil
+		data.Gcp = nil
+	case CloudProviderAzure:
+		if account.SourceAccountAttributes.HasAzure() {
+			azureAttrs := account.SourceAccountAttributes.GetAzure()
+			data.Azure = &AzureAccountConfigModel{
+				TenantId:       types.StringValue(azureAttrs.GetTenantId()),
+				SubscriptionId: types.StringValue(account.GetProviderAccountId()), // subscription_id is the provider_account_id
+			}
+			// ResourceGroupName is not returned in the output model for source accounts
+		}
+		data.Aws = nil
+		data.Gcp = nil
+		data.Role = types.StringNull()
+	case CloudProviderGCP:
+		if account.SourceAccountAttributes.HasGcp() {
+			gcpAttrs := account.SourceAccountAttributes.GetGcp()
+			data.Gcp = &GcpAccountConfigModel{
+				ProjectId:      types.StringValue(account.GetProviderAccountId()), // project_id is the provider_account_id
+				ServiceAccount: types.StringValue(gcpAttrs.GetServiceAccount()),
+			}
+		}
+		data.Aws = nil
+		data.Azure = nil
+		data.Role = types.StringNull()
+	}
+
+	if data.CreatedAt.IsNull() || data.CreatedAt.IsUnknown() {
+		data.CreatedAt = types.StringValue(time.Now().Format(time.RFC3339))
+	}
+	if data.UpdatedAt.IsNull() || data.UpdatedAt.IsUnknown() {
+		data.UpdatedAt = types.StringValue(time.Now().Format(time.RFC3339))
 	}
 
 	// Surface account statuses the provider cannot auto-remediate so the user
@@ -512,19 +504,11 @@ func (r *SourceAccountResource) mapAccountToState(account *externalEonSdkAPI.Sou
 
 // readSourceAccount fetches a source account by ID and maps it to the resource model.
 func (r *SourceAccountResource) readSourceAccount(ctx context.Context, accountId string, plan SourceAccountResourceModel) (*SourceAccountResourceModel, error) {
-	accounts, err := r.client.ListSourceAccounts(ctx)
+	account, err := r.client.GetSourceAccount(ctx, accountId)
 	if err != nil {
-		return nil, fmt.Errorf("unable to list source accounts: %w", err)
+		return nil, fmt.Errorf("unable to get source account: %w", err)
 	}
-
-	for _, account := range accounts {
-		if account.Id != accountId {
-			continue
-		}
-		return r.mapAccountToState(&account, plan), nil
-	}
-
-	return nil, fmt.Errorf("source account %s not found", accountId)
+	return r.mapAccountToState(account, plan), nil
 }
 
 func (r *SourceAccountResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -553,70 +537,60 @@ func (r *SourceAccountResource) Delete(ctx context.Context, req resource.DeleteR
 func (r *SourceAccountResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 
-	accounts, err := r.client.ListSourceAccounts(ctx)
+	account, err := r.client.GetSourceAccount(ctx, req.ID)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read source accounts during import: %s", err))
+		var apiErr *client.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == 404 {
+			resp.Diagnostics.AddError(
+				"Resource Not Found",
+				fmt.Sprintf("Source account with ID %s not found", req.ID),
+			)
+			return
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read source account during import: %s", err))
 		return
 	}
 
-	var found bool
 	var data SourceAccountResourceModel
+	data.Id = types.StringValue(account.Id)
+	data.Name = types.StringValue(account.GetName())
+	data.Status = types.StringValue(string(account.Status))
+	data.ProviderAccountId = types.StringValue(account.GetProviderAccountId())
 
-	for _, account := range accounts {
-		if account.Id == req.ID {
-			found = true
+	cloudProvider := CloudProvider(account.SourceAccountAttributes.GetCloudProvider())
+	data.CloudProvider = types.StringValue(cloudProvider.String())
 
-			data.Id = types.StringValue(account.Id)
-			data.Name = types.StringValue(account.GetName())
-			data.Status = types.StringValue(string(account.Status))
-			data.ProviderAccountId = types.StringValue(account.GetProviderAccountId())
-
-			cloudProvider := CloudProvider(account.SourceAccountAttributes.GetCloudProvider())
-			data.CloudProvider = types.StringValue(cloudProvider.String())
-
-			// Populate cloud-specific blocks from API response
-			switch cloudProvider {
-			case CloudProviderAWS:
-				if account.SourceAccountAttributes.HasAws() {
-					awsAttrs := account.SourceAccountAttributes.GetAws()
-					data.Aws = &AwsAccountConfigModel{
-						RoleArn: types.StringValue(awsAttrs.GetRoleArn()),
-					}
-					// Also populate deprecated role field for backward compatibility
-					data.Role = types.StringValue(awsAttrs.GetRoleArn())
-				}
-			case CloudProviderAzure:
-				if account.SourceAccountAttributes.HasAzure() {
-					azureAttrs := account.SourceAccountAttributes.GetAzure()
-					data.Azure = &AzureAccountConfigModel{
-						TenantId:       types.StringValue(azureAttrs.GetTenantId()),
-						SubscriptionId: types.StringValue(account.GetProviderAccountId()),
-					}
-				}
-			case CloudProviderGCP:
-				if account.SourceAccountAttributes.HasGcp() {
-					gcpAttrs := account.SourceAccountAttributes.GetGcp()
-					data.Gcp = &GcpAccountConfigModel{
-						ProjectId:      types.StringValue(account.GetProviderAccountId()),
-						ServiceAccount: types.StringValue(gcpAttrs.GetServiceAccount()),
-					}
-				}
+	// Populate cloud-specific blocks from API response
+	switch cloudProvider {
+	case CloudProviderAWS:
+		if account.SourceAccountAttributes.HasAws() {
+			awsAttrs := account.SourceAccountAttributes.GetAws()
+			data.Aws = &AwsAccountConfigModel{
+				RoleArn: types.StringValue(awsAttrs.GetRoleArn()),
 			}
-
-			data.CreatedAt = types.StringValue(time.Now().Format(time.RFC3339))
-			data.UpdatedAt = types.StringValue(time.Now().Format(time.RFC3339))
-
-			break
+			// Also populate deprecated role field for backward compatibility
+			data.Role = types.StringValue(awsAttrs.GetRoleArn())
+		}
+	case CloudProviderAzure:
+		if account.SourceAccountAttributes.HasAzure() {
+			azureAttrs := account.SourceAccountAttributes.GetAzure()
+			data.Azure = &AzureAccountConfigModel{
+				TenantId:       types.StringValue(azureAttrs.GetTenantId()),
+				SubscriptionId: types.StringValue(account.GetProviderAccountId()),
+			}
+		}
+	case CloudProviderGCP:
+		if account.SourceAccountAttributes.HasGcp() {
+			gcpAttrs := account.SourceAccountAttributes.GetGcp()
+			data.Gcp = &GcpAccountConfigModel{
+				ProjectId:      types.StringValue(account.GetProviderAccountId()),
+				ServiceAccount: types.StringValue(gcpAttrs.GetServiceAccount()),
+			}
 		}
 	}
 
-	if !found {
-		resp.Diagnostics.AddError(
-			"Resource Not Found",
-			fmt.Sprintf("Source account with ID %s not found", req.ID),
-		)
-		return
-	}
+	data.CreatedAt = types.StringValue(time.Now().Format(time.RFC3339))
+	data.UpdatedAt = types.StringValue(time.Now().Format(time.RFC3339))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 


### PR DESCRIPTION
## Summary
- Bump `eon-sdk-go` from v1.117.0 to v1.118.0, which exposes `GET /v1/projects/{projectId}/source-accounts/{accountId}`.
- Add `GetSourceAccount` to the internal client, returning a 404-aware `*APIError` so callers can distinguish "gone" from other failures.
- Swap the three by-ID lookups on the resource (`Read`, `readSourceAccount` helper, `ImportState`) from list-and-filter to single-fetch. `findExistingAccount` (searches by cloud attrs) and the source accounts data source stay on `ListSourceAccounts`.

## Test plan
- [x] `go build ./...`
- [ ] `terraform plan` / `apply` against an existing source account (Read path)
- [ ] `terraform import eon_source_account.foo <id>` (ImportState path)
- [ ] Delete account out-of-band, re-run plan — expect resource to be removed from state (404 handling in Read)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://eon.devinenterprise.com/review/eon-io/terraform-provider-eon/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
