### PR TITLE
(EON-9826) fix: handle 404 in backup policy Read as drift

### DIFF
--- a/internal/provider/resource_backup_policy.go
+++ b/internal/provider/resource_backup_policy.go
@@ -2,7 +2,9 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	externalEonSdkAPI "github.com/eon-io/eon-sdk-go"
@@ -1069,6 +1071,14 @@ func (r *BackupPolicyResource) Read(ctx context.Context, req resource.ReadReques
 
 	policy, err := r.client.GetBackupPolicy(ctx, data.Id.ValueString())
 	if err != nil {
+		var apiErr *client.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			tflog.Warn(ctx, "Backup policy not found, removing from state", map[string]interface{}{
+				"id": data.Id.ValueString(),
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read backup policy: %s", err))
 		return
 	}


### PR DESCRIPTION
## Summary

Fixes [EON-9826](https://linear.app/eon-io/issue/EON-9826/api-404-when-trying-to-create-backup-policies-using-terraform). When a backup policy is deleted out-of-band (e.g. via the Eon UI), `terraform plan/apply` errored with:

```
Error: Client Error
Unable to read backup policy: API error 404: {"error":"failed to read backup policy: record not found"}: 404 Not Found
```

The provider's `Read` treated the 404 as a fatal diagnostic, so Terraform never got to plan a Create for the renamed/replacement resource. State was permanently wedged on the dead UUID.

This change detects `*client.APIError` with `StatusCode == 404` in the backup policy `Read`, emits a warning via `tflog`, and calls `resp.State.RemoveResource(ctx)`. Terraform then plans a Create on the next run — the standard drift-handling pattern already used by `resource_vault.go` and `resource_source_account.go` for similar cases.

## Customer impact

SoFi created backup policies via Terraform, deleted them in the Eon UI to redo their config, then re-applied with renamed policies — and got stuck on 404s. This unblocks that workflow without manual `terraform state rm`.

## Test plan

- [ ] `go build ./...` and `go vet ./...` pass locally
- [ ] Reproduce locally: create a backup policy via TF, delete it via the API (or UI), re-run `terraform plan` — verify it now plans a Create instead of erroring
- [ ] Verify a non-404 error (e.g. 500) still surfaces as a fatal diagnostic

## Follow-ups (separate PRs)

- Audit the other resource `Read` functions in this repo for the same drift-handling gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)