### PR TITLE
chore: bump eon-sdk-go to v1.138.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.4
 
 require (
-	github.com/eon-io/eon-sdk-go v1.125.0
+	github.com/eon-io/eon-sdk-go v1.138.0
 	github.com/hashicorp/terraform-plugin-docs v0.24.0
 	github.com/hashicorp/terraform-plugin-framework v1.13.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/eon-io/eon-sdk-go v1.125.0 h1:rKeAb+CMNVe/T5IpOADK2zy4VEp2+t7N+DJLDYq7H6w=
-github.com/eon-io/eon-sdk-go v1.125.0/go.mod h1:NWrS3rllESPQ7vzryT7+bHkOpNrXbXcnRtaPlv0LScw=
+github.com/eon-io/eon-sdk-go v1.138.0 h1:WF+fseXl9BhU264riFN2fWO+/PlHuqJeVKtrX8tervQ=
+github.com/eon-io/eon-sdk-go v1.138.0/go.mod h1:NWrS3rllESPQ7vzryT7+bHkOpNrXbXcnRtaPlv0LScw=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -225,16 +225,6 @@ func (c *EonClient) DisconnectSourceAccount(ctx context.Context, accountId strin
 	return nil
 }
 
-// DeleteSourceAccount deletes a source account.
-//
-// TODO(EON-11410): This is a stub. The eon-sdk-go client does not yet expose a
-// DeleteSourceAccount API. Once the SDK is updated, replace this stub with a
-// real call to c.client.AccountsAPI.DeleteSourceAccount following the same
-// pattern as DisconnectSourceAccount above.
-func (c *EonClient) DeleteSourceAccount(ctx context.Context, accountId string) error {
-	return fmt.Errorf("DeleteSourceAccount is not yet implemented: pending SDK support (EON-11410)")
-}
-
 // UpdateSourceAccountRequest contains the fields that can be updated on a source account.
 type UpdateSourceAccountRequest struct {
 	Name                    *string

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -225,6 +225,16 @@ func (c *EonClient) DisconnectSourceAccount(ctx context.Context, accountId strin
 	return nil
 }
 
+// DeleteSourceAccount deletes a source account.
+//
+// TODO(EON-11410): This is a stub. The eon-sdk-go client does not yet expose a
+// DeleteSourceAccount API. Once the SDK is updated, replace this stub with a
+// real call to c.client.AccountsAPI.DeleteSourceAccount following the same
+// pattern as DisconnectSourceAccount above.
+func (c *EonClient) DeleteSourceAccount(ctx context.Context, accountId string) error {
+	return fmt.Errorf("DeleteSourceAccount is not yet implemented: pending SDK support (EON-11410)")
+}
+
 // UpdateSourceAccountRequest contains the fields that can be updated on a source account.
 type UpdateSourceAccountRequest struct {
 	Name                    *string

--- a/internal/provider/resource_backup_policy.go
+++ b/internal/provider/resource_backup_policy.go
@@ -1933,13 +1933,8 @@ func createBackupPolicyExpression(ctx context.Context, data *ResourceSelectorMod
 					return nil, fmt.Errorf("failed to parse data_classes list in operand")
 				}
 
-				var dataClassEnums []externalEonSdkAPI.DataClass
-				for _, dc := range dataClasses {
-					dataClassEnums = append(dataClassEnums, externalEonSdkAPI.DataClass(dc))
-				}
-
 				operator := externalEonSdkAPI.ListOperators(dataClassesCondition.Operator.ValueString())
-				dataClassesConditionApi := externalEonSdkAPI.NewDataClassesCondition(operator, dataClassEnums)
+				dataClassesConditionApi := externalEonSdkAPI.NewDataClassesCondition(operator, dataClasses)
 				operandExpr.SetDataClasses(*dataClassesConditionApi)
 			}
 

--- a/internal/provider/role_access_condition.go
+++ b/internal/provider/role_access_condition.go
@@ -502,11 +502,7 @@ func roleDataClassesConditionToSDK(ctx context.Context, obj types.Object) (*exte
 	op := externalEonSdkAPI.ListOperators(attrs["operator"].(types.String).ValueString())
 	var list []string
 	_ = attrs["data_classes"].(types.List).ElementsAs(ctx, &list, false)
-	dcs := make([]externalEonSdkAPI.DataClass, len(list))
-	for i, s := range list {
-		dcs[i] = externalEonSdkAPI.DataClass(s)
-	}
-	c := externalEonSdkAPI.NewDataClassesCondition(op, dcs)
+	c := externalEonSdkAPI.NewDataClassesCondition(op, list)
 	return c, nil
 }
 


### PR DESCRIPTION
## Summary
- Bumps `eon-sdk-go` from `v1.125.0` to `v1.138.0` (latest).
- Adapts to a breaking change: the SDK removed the `DataClass` enum type, and `DataClassesCondition` now takes a plain `[]string`. Updated the two call sites in `resource_backup_policy.go` and `role_access_condition.go` to drop the now-unneeded conversion loops.

## Notes
- The `DeleteSourceAccount` client stub originally added on this branch (EON-11410) has been removed — v1.138.0 still does not expose a delete-source-account endpoint, so there was no dead stub left to ship.

## Verification
- `go build ./...`, `go vet ./...`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)