### PR TITLE
feat: delete source account on resource destroy (EON-11410)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.4
 
 require (
-	github.com/eon-io/eon-sdk-go v1.138.0
+	github.com/eon-io/eon-sdk-go v1.139.0
 	github.com/hashicorp/terraform-plugin-docs v0.24.0
 	github.com/hashicorp/terraform-plugin-framework v1.13.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/eon-io/eon-sdk-go v1.138.0 h1:WF+fseXl9BhU264riFN2fWO+/PlHuqJeVKtrX8tervQ=
-github.com/eon-io/eon-sdk-go v1.138.0/go.mod h1:NWrS3rllESPQ7vzryT7+bHkOpNrXbXcnRtaPlv0LScw=
+github.com/eon-io/eon-sdk-go v1.139.0 h1:1yGXZoiWNcpkapYv3OpiYiuk25VC+pTjGdz/tjzkGPA=
+github.com/eon-io/eon-sdk-go v1.139.0/go.mod h1:NWrS3rllESPQ7vzryT7+bHkOpNrXbXcnRtaPlv0LScw=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -225,6 +225,27 @@ func (c *EonClient) DisconnectSourceAccount(ctx context.Context, accountId strin
 	return nil
 }
 
+// DeleteSourceAccount fully removes a source account from the project.
+// Callers should typically Disconnect first if the account is still connected.
+func (c *EonClient) DeleteSourceAccount(ctx context.Context, accountId string) error {
+	if err := c.tokenRefresher.EnsureValidToken(); err != nil {
+		return fmt.Errorf("failed to ensure valid token: %w", err)
+	}
+
+	httpResp, err := c.client.AccountsAPI.DeleteSourceAccount(ctx, c.projectID, accountId).Execute()
+	if apiErr := c.handleAPIError(err, httpResp, "failed to delete source account"); apiErr != nil {
+		return apiErr
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK && httpResp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(httpResp.Body)
+		return fmt.Errorf("API error %d: %s", httpResp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
 // UpdateSourceAccountRequest contains the fields that can be updated on a source account.
 type UpdateSourceAccountRequest struct {
 	Name                    *string

--- a/internal/provider/resource_source_account.go
+++ b/internal/provider/resource_source_account.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	externalEonSdkAPI "github.com/eon-io/eon-sdk-go"
@@ -519,19 +520,29 @@ func (r *SourceAccountResource) Delete(ctx context.Context, req resource.DeleteR
 		return
 	}
 
-	tflog.Debug(ctx, "Disconnecting source account", map[string]interface{}{
-		"id": data.Id.ValueString(),
-	})
+	id := data.Id.ValueString()
 
-	err := r.client.DisconnectSourceAccount(ctx, data.Id.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to disconnect source account: %s", err))
+	if strings.EqualFold(data.Status.ValueString(), "CONNECTED") {
+		tflog.Debug(ctx, "Disconnecting source account before delete", map[string]interface{}{"id": id})
+		if err := r.client.DisconnectSourceAccount(ctx, id); err != nil {
+			tflog.Warn(ctx, "Disconnect failed during delete; proceeding to delete anyway", map[string]interface{}{
+				"id":    id,
+				"error": err.Error(),
+			})
+			resp.Diagnostics.AddWarning(
+				"Disconnect Failed",
+				fmt.Sprintf("Could not disconnect source account before delete (proceeding with delete): %s", err),
+			)
+		}
+	}
+
+	tflog.Debug(ctx, "Deleting source account", map[string]interface{}{"id": id})
+	if err := r.client.DeleteSourceAccount(ctx, id); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete source account: %s", err))
 		return
 	}
 
-	tflog.Debug(ctx, "Source account disconnected", map[string]interface{}{
-		"id": data.Id.ValueString(),
-	})
+	tflog.Debug(ctx, "Source account deleted", map[string]interface{}{"id": id})
 }
 
 func (r *SourceAccountResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {


### PR DESCRIPTION
## Summary

Implements full deletion of source accounts on resource destroy, mirroring the existing restore account delete flow.

- Adds `DeleteSourceAccount` client method calling the new `AccountsAPI.DeleteSourceAccount` SDK endpoint (available as of eon-sdk-go `v1.139.0`).
- Updates `SourceAccountResource.Delete` to disconnect the account first if it is `CONNECTED` (warn-and-proceed if disconnect fails), then fully delete it.
- Bumps `eon-sdk-go` `v1.138.0` → `v1.139.0`.

Previously, destroying a source account only **disconnected** it, leaving the record in the project. It now fully deletes the account, consistent with restore accounts.

The SDK enforces the same precondition as restore accounts: only `DISCONNECTED` / `INSUFFICIENT_PERMISSIONS` accounts can be deleted, so `CONNECTED` accounts must be disconnected first.

## Test plan

- `go build ./...`
- `go vet ./internal/...`
- `go test ./internal/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)