### PR TITLE
feat(aws-ou): add aws-ou-onboarding module that provisions member roles (EON-12736)

### DIFF
--- a/docs/resources/source_aws_organizational_unit.md
+++ b/docs/resources/source_aws_organizational_unit.md
@@ -3,39 +3,134 @@
 page_title: "eon_source_aws_organizational_unit Resource - terraform-provider-eon"
 subcategory: ""
 description: |-
-  Connects a source AWS organizational unit to the Eon project. All AWS accounts within the organizational unit (and its nested OUs) will be automatically discovered and available for backup.
+  Connects a source AWS organizational unit to the Eon project. All AWS accounts within the organizational unit (and its nested OUs) are automatically discovered and available for backup.
+  Prerequisite: connecting an OU only makes Eon discover member accounts and assume a role named EonSourceAccountRole in each one — it does not create that role. You must separately deploy EonSourceAccountRole into every member account, normally via a service-managed CloudFormation StackSet that auto-deploys to the OU (see the example). Without it, member accounts are discovered but have no permissions.
 ---
 
 # eon_source_aws_organizational_unit (Resource)
 
-Connects a source AWS organizational unit to the Eon project. All AWS accounts within the organizational unit (and its nested OUs) will be automatically discovered and available for backup.
+Connects a source AWS organizational unit to the Eon project. All AWS accounts within the organizational unit (and its nested OUs) are automatically discovered and available for backup.
+
+**Prerequisite:** connecting an OU only makes Eon discover member accounts and assume a role named `EonSourceAccountRole` in each one — it does not create that role. You must separately deploy `EonSourceAccountRole` into every member account, normally via a service-managed CloudFormation StackSet that auto-deploys to the OU (see the example). Without it, member accounts are discovered but have no permissions.
 
 ## Example Usage
 
 ```terraform
-# Example: Connect an AWS organizational unit for backup operations
-resource "eon_source_aws_organizational_unit" "production" {
-  role_arn                        = "arn:aws:iam::123456789012:role/EonOrgUnitRole"
-  provider_organizational_unit_id = "ou-abc1-23456789"
+# Onboarding an AWS Organizational Unit to Eon is a TWO-part operation:
+#
+#   1. eon_source_aws_organizational_unit (below) registers the OU with Eon. Eon
+#      then DISCOVERS every member account and ASSUMES a role named
+#      `EonSourceAccountRole` in each one.
+#   2. A role named `EonSourceAccountRole` must actually EXIST in every member
+#      account. Registration does NOT create it. The service-managed
+#      CloudFormation StackSet below creates it across the whole OU (and, via
+#      auto-deployment, in any account that later joins the OU).
+#
+# Doing step 1 without step 2 leaves member accounts discovered but with no
+# permissions. This mirrors Eon's official `aws-organization.yml` onboarding,
+# which bundles the same StackSet.
+#
+# Prerequisite: enable CloudFormation trusted access with AWS Organizations once
+# in the management account (`aws cloudformation activate-organizations-access`),
+# otherwise the SERVICE_MANAGED StackSet cannot be created.
+
+variable "eon_account_id" {
+  type        = string
+  description = "Eon-registered account ID (used as the STS ExternalId / confused-deputy guard)."
 }
 
-# Example: Connect another AWS organizational unit
-resource "eon_source_aws_organizational_unit" "staging" {
-  role_arn                        = "arn:aws:iam::987654321098:role/EonOrgUnitRole"
-  provider_organizational_unit_id = "ou-def2-98765432"
+variable "organizational_unit_ids" {
+  type        = set(string)
+  description = "AWS Organizational Unit IDs to onboard (e.g. ou-abc1-23456789)."
 }
 
-# Output the organizational unit details
-output "production_ou" {
-  description = "Details of the connected AWS production organizational unit"
-  value = {
-    id                              = eon_source_aws_organizational_unit.production.id
-    name                            = eon_source_aws_organizational_unit.production.name
-    status                          = eon_source_aws_organizational_unit.production.status
-    provider_organizational_unit_id = eon_source_aws_organizational_unit.production.provider_organizational_unit_id
-    provider_management_account_id  = eon_source_aws_organizational_unit.production.provider_management_account_id
-    created_at                      = eon_source_aws_organizational_unit.production.created_at
+variable "aws_region" {
+  type        = string
+  description = "Region to deploy the member-account roles in."
+  default     = "us-east-1"
+}
+
+# (1) Discovery role in the management account: lets Eon enumerate the OU's
+# accounts and assume EonSourceAccountRole in each member.
+resource "aws_iam_role" "eon_org_unit" {
+  name = "EonOrgUnitRole"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { AWS = ["arn:aws:iam::058264520728:root", "arn:aws:iam::010438478826:root"] }
+      Action    = "sts:AssumeRole"
+      Condition = { StringEquals = { "sts:ExternalId" = var.eon_account_id } }
+    }]
+  })
+
+  inline_policy {
+    name = "EonOrgUnitPolicy"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect = "Allow"
+          Action = [
+            "organizations:ListAccountsForParent",
+            "organizations:ListOrganizationalUnitsForParent",
+            "organizations:DescribeOrganizationalUnit",
+          ]
+          Resource = "*"
+        },
+        {
+          Effect   = "Allow"
+          Action   = "sts:AssumeRole"
+          Resource = "arn:aws:iam::*:role/EonSourceAccountRole"
+        },
+      ]
+    })
   }
+}
+
+# (2) Create EonSourceAccountRole in every member account of the OU.
+resource "aws_cloudformation_stack_set" "eon_source_members" {
+  name             = "EonSourceAccountOrgDeployment"
+  permission_model = "SERVICE_MANAGED"
+  capabilities     = ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"]
+  template_url     = "https://eon-public-b2b628cc-1d96-4fda-8dae-c3b1ad3ea03b.s3.amazonaws.com/source-account.yml"
+
+  auto_deployment {
+    enabled                          = true
+    retain_stacks_on_account_removal = false
+  }
+
+  managed_execution { active = true }
+
+  parameters = {
+    EonAccountId = var.eon_account_id
+    RoleName     = "EonSourceAccountRole"
+    # source-account.yml exposes EnableS3CdcBackup, EnableEKS, EnableAwsBackup, …
+    # capability flags — set them here as needed; sensible defaults apply otherwise.
+  }
+
+  lifecycle { ignore_changes = [administration_role_arn] }
+}
+
+resource "aws_cloudformation_stack_set_instance" "eon_source_members" {
+  stack_set_name = aws_cloudformation_stack_set.eon_source_members.name
+
+  deployment_targets {
+    organizational_unit_ids = var.organizational_unit_ids
+  }
+
+  region = var.aws_region
+}
+
+# (1, cont.) Register each OU with Eon, only after member roles are being deployed.
+resource "eon_source_aws_organizational_unit" "this" {
+  for_each = var.organizational_unit_ids
+
+  role_arn                        = aws_iam_role.eon_org_unit.arn
+  provider_organizational_unit_id = each.value
+
+  depends_on = [aws_cloudformation_stack_set_instance.eon_source_members]
 }
 ```
 

--- a/docs/resources/source_aws_organizational_unit.md
+++ b/docs/resources/source_aws_organizational_unit.md
@@ -16,121 +16,46 @@ Connects a source AWS organizational unit to the Eon project. All AWS accounts w
 ## Example Usage
 
 ```terraform
-# Onboarding an AWS Organizational Unit to Eon is a TWO-part operation:
+# Onboarding an AWS Organizational Unit is a TWO-part operation:
 #
-#   1. eon_source_aws_organizational_unit (below) registers the OU with Eon. Eon
-#      then DISCOVERS every member account and ASSUMES a role named
-#      `EonSourceAccountRole` in each one.
-#   2. A role named `EonSourceAccountRole` must actually EXIST in every member
-#      account. Registration does NOT create it. The service-managed
-#      CloudFormation StackSet below creates it across the whole OU (and, via
-#      auto-deployment, in any account that later joins the OU).
+#   1. eon_source_aws_organizational_unit (below) registers the OU with Eon — Eon
+#      then DISCOVERS the member accounts and ASSUMES `EonSourceAccountRole` in
+#      each one.
+#   2. That role must actually EXIST in every member account. Registration does
+#      NOT create it; a CloudFormation StackSet does.
 #
-# Doing step 1 without step 2 leaves member accounts discovered but with no
-# permissions. This mirrors Eon's official `aws-organization.yml` onboarding,
-# which bundles the same StackSet.
+# Using this resource on its own leaves members discovered but with no
+# permissions. For real onboarding use the `aws-ou-onboarding` module, which does
+# BOTH parts (registration + the StackSet that creates the member roles, plus the
+# management-account discovery role). See modules/aws-ou-onboarding/README.md:
 #
-# Prerequisite: enable CloudFormation trusted access with AWS Organizations once
-# in the management account (`aws cloudformation activate-organizations-access`),
-# otherwise the SERVICE_MANAGED StackSet cannot be created.
+#   module "eon_ou_onboarding" {
+#     source = "github.com/eon-io/terraform-provider-eon//modules/aws-ou-onboarding"
+#
+#     eon_account_id          = "fde6adb5-38bc-45a3-919e-bd9ee17d9ba4"
+#     scanning_account_id     = "388762879875"
+#     organizational_unit_ids = ["ou-abc1-23456789", "ou-abc1-98765432"]
+#   }
 
-variable "eon_account_id" {
-  type        = string
-  description = "Eon-registered account ID (used as the STS ExternalId / confused-deputy guard)."
+# Bare registration — only valid when EonSourceAccountRole already exists in every
+# member account (e.g. deployed by the module above, a separate StackSet, or Eon's
+# aws-organization.yml CloudFormation template).
+resource "eon_source_aws_organizational_unit" "production" {
+  role_arn                        = "arn:aws:iam::123456789012:role/EonOrgUnitRole"
+  provider_organizational_unit_id = "ou-abc1-23456789"
 }
 
-variable "organizational_unit_ids" {
-  type        = set(string)
-  description = "AWS Organizational Unit IDs to onboard (e.g. ou-abc1-23456789)."
-}
-
-variable "aws_region" {
-  type        = string
-  description = "Region to deploy the member-account roles in."
-  default     = "us-east-1"
-}
-
-# (1) Discovery role in the management account: lets Eon enumerate the OU's
-# accounts and assume EonSourceAccountRole in each member.
-resource "aws_iam_role" "eon_org_unit" {
-  name = "EonOrgUnitRole"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect    = "Allow"
-      Principal = { AWS = ["arn:aws:iam::058264520728:root", "arn:aws:iam::010438478826:root"] }
-      Action    = "sts:AssumeRole"
-      Condition = { StringEquals = { "sts:ExternalId" = var.eon_account_id } }
-    }]
-  })
-
-  inline_policy {
-    name = "EonOrgUnitPolicy"
-    policy = jsonencode({
-      Version = "2012-10-17"
-      Statement = [
-        {
-          Effect = "Allow"
-          Action = [
-            "organizations:ListAccountsForParent",
-            "organizations:ListOrganizationalUnitsForParent",
-            "organizations:DescribeOrganizationalUnit",
-          ]
-          Resource = "*"
-        },
-        {
-          Effect   = "Allow"
-          Action   = "sts:AssumeRole"
-          Resource = "arn:aws:iam::*:role/EonSourceAccountRole"
-        },
-      ]
-    })
+# Output the organizational unit details
+output "production_ou" {
+  description = "Details of the connected AWS production organizational unit"
+  value = {
+    id                              = eon_source_aws_organizational_unit.production.id
+    name                            = eon_source_aws_organizational_unit.production.name
+    status                          = eon_source_aws_organizational_unit.production.status
+    provider_organizational_unit_id = eon_source_aws_organizational_unit.production.provider_organizational_unit_id
+    provider_management_account_id  = eon_source_aws_organizational_unit.production.provider_management_account_id
+    created_at                      = eon_source_aws_organizational_unit.production.created_at
   }
-}
-
-# (2) Create EonSourceAccountRole in every member account of the OU.
-resource "aws_cloudformation_stack_set" "eon_source_members" {
-  name             = "EonSourceAccountOrgDeployment"
-  permission_model = "SERVICE_MANAGED"
-  capabilities     = ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"]
-  template_url     = "https://eon-public-b2b628cc-1d96-4fda-8dae-c3b1ad3ea03b.s3.amazonaws.com/source-account.yml"
-
-  auto_deployment {
-    enabled                          = true
-    retain_stacks_on_account_removal = false
-  }
-
-  managed_execution { active = true }
-
-  parameters = {
-    EonAccountId = var.eon_account_id
-    RoleName     = "EonSourceAccountRole"
-    # source-account.yml exposes EnableS3CdcBackup, EnableEKS, EnableAwsBackup, …
-    # capability flags — set them here as needed; sensible defaults apply otherwise.
-  }
-
-  lifecycle { ignore_changes = [administration_role_arn] }
-}
-
-resource "aws_cloudformation_stack_set_instance" "eon_source_members" {
-  stack_set_name = aws_cloudformation_stack_set.eon_source_members.name
-
-  deployment_targets {
-    organizational_unit_ids = var.organizational_unit_ids
-  }
-
-  region = var.aws_region
-}
-
-# (1, cont.) Register each OU with Eon, only after member roles are being deployed.
-resource "eon_source_aws_organizational_unit" "this" {
-  for_each = var.organizational_unit_ids
-
-  role_arn                        = aws_iam_role.eon_org_unit.arn
-  provider_organizational_unit_id = each.value
-
-  depends_on = [aws_cloudformation_stack_set_instance.eon_source_members]
 }
 ```
 

--- a/examples/resources/eon_source_aws_organizational_unit/resource.tf
+++ b/examples/resources/eon_source_aws_organizational_unit/resource.tf
@@ -1,24 +1,116 @@
-# Example: Connect an AWS organizational unit for backup operations
-resource "eon_source_aws_organizational_unit" "production" {
-  role_arn                        = "arn:aws:iam::123456789012:role/EonOrgUnitRole"
-  provider_organizational_unit_id = "ou-abc1-23456789"
+# Onboarding an AWS Organizational Unit to Eon is a TWO-part operation:
+#
+#   1. eon_source_aws_organizational_unit (below) registers the OU with Eon. Eon
+#      then DISCOVERS every member account and ASSUMES a role named
+#      `EonSourceAccountRole` in each one.
+#   2. A role named `EonSourceAccountRole` must actually EXIST in every member
+#      account. Registration does NOT create it. The service-managed
+#      CloudFormation StackSet below creates it across the whole OU (and, via
+#      auto-deployment, in any account that later joins the OU).
+#
+# Doing step 1 without step 2 leaves member accounts discovered but with no
+# permissions. This mirrors Eon's official `aws-organization.yml` onboarding,
+# which bundles the same StackSet.
+#
+# Prerequisite: enable CloudFormation trusted access with AWS Organizations once
+# in the management account (`aws cloudformation activate-organizations-access`),
+# otherwise the SERVICE_MANAGED StackSet cannot be created.
+
+variable "eon_account_id" {
+  type        = string
+  description = "Eon-registered account ID (used as the STS ExternalId / confused-deputy guard)."
 }
 
-# Example: Connect another AWS organizational unit
-resource "eon_source_aws_organizational_unit" "staging" {
-  role_arn                        = "arn:aws:iam::987654321098:role/EonOrgUnitRole"
-  provider_organizational_unit_id = "ou-def2-98765432"
+variable "organizational_unit_ids" {
+  type        = set(string)
+  description = "AWS Organizational Unit IDs to onboard (e.g. ou-abc1-23456789)."
 }
 
-# Output the organizational unit details
-output "production_ou" {
-  description = "Details of the connected AWS production organizational unit"
-  value = {
-    id                              = eon_source_aws_organizational_unit.production.id
-    name                            = eon_source_aws_organizational_unit.production.name
-    status                          = eon_source_aws_organizational_unit.production.status
-    provider_organizational_unit_id = eon_source_aws_organizational_unit.production.provider_organizational_unit_id
-    provider_management_account_id  = eon_source_aws_organizational_unit.production.provider_management_account_id
-    created_at                      = eon_source_aws_organizational_unit.production.created_at
+variable "aws_region" {
+  type        = string
+  description = "Region to deploy the member-account roles in."
+  default     = "us-east-1"
+}
+
+# (1) Discovery role in the management account: lets Eon enumerate the OU's
+# accounts and assume EonSourceAccountRole in each member.
+resource "aws_iam_role" "eon_org_unit" {
+  name = "EonOrgUnitRole"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { AWS = ["arn:aws:iam::058264520728:root", "arn:aws:iam::010438478826:root"] }
+      Action    = "sts:AssumeRole"
+      Condition = { StringEquals = { "sts:ExternalId" = var.eon_account_id } }
+    }]
+  })
+
+  inline_policy {
+    name = "EonOrgUnitPolicy"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect = "Allow"
+          Action = [
+            "organizations:ListAccountsForParent",
+            "organizations:ListOrganizationalUnitsForParent",
+            "organizations:DescribeOrganizationalUnit",
+          ]
+          Resource = "*"
+        },
+        {
+          Effect   = "Allow"
+          Action   = "sts:AssumeRole"
+          Resource = "arn:aws:iam::*:role/EonSourceAccountRole"
+        },
+      ]
+    })
   }
+}
+
+# (2) Create EonSourceAccountRole in every member account of the OU.
+resource "aws_cloudformation_stack_set" "eon_source_members" {
+  name             = "EonSourceAccountOrgDeployment"
+  permission_model = "SERVICE_MANAGED"
+  capabilities     = ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"]
+  template_url     = "https://eon-public-b2b628cc-1d96-4fda-8dae-c3b1ad3ea03b.s3.amazonaws.com/source-account.yml"
+
+  auto_deployment {
+    enabled                          = true
+    retain_stacks_on_account_removal = false
+  }
+
+  managed_execution { active = true }
+
+  parameters = {
+    EonAccountId = var.eon_account_id
+    RoleName     = "EonSourceAccountRole"
+    # source-account.yml exposes EnableS3CdcBackup, EnableEKS, EnableAwsBackup, …
+    # capability flags — set them here as needed; sensible defaults apply otherwise.
+  }
+
+  lifecycle { ignore_changes = [administration_role_arn] }
+}
+
+resource "aws_cloudformation_stack_set_instance" "eon_source_members" {
+  stack_set_name = aws_cloudformation_stack_set.eon_source_members.name
+
+  deployment_targets {
+    organizational_unit_ids = var.organizational_unit_ids
+  }
+
+  region = var.aws_region
+}
+
+# (1, cont.) Register each OU with Eon, only after member roles are being deployed.
+resource "eon_source_aws_organizational_unit" "this" {
+  for_each = var.organizational_unit_ids
+
+  role_arn                        = aws_iam_role.eon_org_unit.arn
+  provider_organizational_unit_id = each.value
+
+  depends_on = [aws_cloudformation_stack_set_instance.eon_source_members]
 }

--- a/examples/resources/eon_source_aws_organizational_unit/resource.tf
+++ b/examples/resources/eon_source_aws_organizational_unit/resource.tf
@@ -1,116 +1,41 @@
-# Onboarding an AWS Organizational Unit to Eon is a TWO-part operation:
+# Onboarding an AWS Organizational Unit is a TWO-part operation:
 #
-#   1. eon_source_aws_organizational_unit (below) registers the OU with Eon. Eon
-#      then DISCOVERS every member account and ASSUMES a role named
-#      `EonSourceAccountRole` in each one.
-#   2. A role named `EonSourceAccountRole` must actually EXIST in every member
-#      account. Registration does NOT create it. The service-managed
-#      CloudFormation StackSet below creates it across the whole OU (and, via
-#      auto-deployment, in any account that later joins the OU).
+#   1. eon_source_aws_organizational_unit (below) registers the OU with Eon — Eon
+#      then DISCOVERS the member accounts and ASSUMES `EonSourceAccountRole` in
+#      each one.
+#   2. That role must actually EXIST in every member account. Registration does
+#      NOT create it; a CloudFormation StackSet does.
 #
-# Doing step 1 without step 2 leaves member accounts discovered but with no
-# permissions. This mirrors Eon's official `aws-organization.yml` onboarding,
-# which bundles the same StackSet.
+# Using this resource on its own leaves members discovered but with no
+# permissions. For real onboarding use the `aws-ou-onboarding` module, which does
+# BOTH parts (registration + the StackSet that creates the member roles, plus the
+# management-account discovery role). See modules/aws-ou-onboarding/README.md:
 #
-# Prerequisite: enable CloudFormation trusted access with AWS Organizations once
-# in the management account (`aws cloudformation activate-organizations-access`),
-# otherwise the SERVICE_MANAGED StackSet cannot be created.
+#   module "eon_ou_onboarding" {
+#     source = "github.com/eon-io/terraform-provider-eon//modules/aws-ou-onboarding"
+#
+#     eon_account_id          = "fde6adb5-38bc-45a3-919e-bd9ee17d9ba4"
+#     scanning_account_id     = "388762879875"
+#     organizational_unit_ids = ["ou-abc1-23456789", "ou-abc1-98765432"]
+#   }
 
-variable "eon_account_id" {
-  type        = string
-  description = "Eon-registered account ID (used as the STS ExternalId / confused-deputy guard)."
+# Bare registration — only valid when EonSourceAccountRole already exists in every
+# member account (e.g. deployed by the module above, a separate StackSet, or Eon's
+# aws-organization.yml CloudFormation template).
+resource "eon_source_aws_organizational_unit" "production" {
+  role_arn                        = "arn:aws:iam::123456789012:role/EonOrgUnitRole"
+  provider_organizational_unit_id = "ou-abc1-23456789"
 }
 
-variable "organizational_unit_ids" {
-  type        = set(string)
-  description = "AWS Organizational Unit IDs to onboard (e.g. ou-abc1-23456789)."
-}
-
-variable "aws_region" {
-  type        = string
-  description = "Region to deploy the member-account roles in."
-  default     = "us-east-1"
-}
-
-# (1) Discovery role in the management account: lets Eon enumerate the OU's
-# accounts and assume EonSourceAccountRole in each member.
-resource "aws_iam_role" "eon_org_unit" {
-  name = "EonOrgUnitRole"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect    = "Allow"
-      Principal = { AWS = ["arn:aws:iam::058264520728:root", "arn:aws:iam::010438478826:root"] }
-      Action    = "sts:AssumeRole"
-      Condition = { StringEquals = { "sts:ExternalId" = var.eon_account_id } }
-    }]
-  })
-
-  inline_policy {
-    name = "EonOrgUnitPolicy"
-    policy = jsonencode({
-      Version = "2012-10-17"
-      Statement = [
-        {
-          Effect = "Allow"
-          Action = [
-            "organizations:ListAccountsForParent",
-            "organizations:ListOrganizationalUnitsForParent",
-            "organizations:DescribeOrganizationalUnit",
-          ]
-          Resource = "*"
-        },
-        {
-          Effect   = "Allow"
-          Action   = "sts:AssumeRole"
-          Resource = "arn:aws:iam::*:role/EonSourceAccountRole"
-        },
-      ]
-    })
+# Output the organizational unit details
+output "production_ou" {
+  description = "Details of the connected AWS production organizational unit"
+  value = {
+    id                              = eon_source_aws_organizational_unit.production.id
+    name                            = eon_source_aws_organizational_unit.production.name
+    status                          = eon_source_aws_organizational_unit.production.status
+    provider_organizational_unit_id = eon_source_aws_organizational_unit.production.provider_organizational_unit_id
+    provider_management_account_id  = eon_source_aws_organizational_unit.production.provider_management_account_id
+    created_at                      = eon_source_aws_organizational_unit.production.created_at
   }
-}
-
-# (2) Create EonSourceAccountRole in every member account of the OU.
-resource "aws_cloudformation_stack_set" "eon_source_members" {
-  name             = "EonSourceAccountOrgDeployment"
-  permission_model = "SERVICE_MANAGED"
-  capabilities     = ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"]
-  template_url     = "https://eon-public-b2b628cc-1d96-4fda-8dae-c3b1ad3ea03b.s3.amazonaws.com/source-account.yml"
-
-  auto_deployment {
-    enabled                          = true
-    retain_stacks_on_account_removal = false
-  }
-
-  managed_execution { active = true }
-
-  parameters = {
-    EonAccountId = var.eon_account_id
-    RoleName     = "EonSourceAccountRole"
-    # source-account.yml exposes EnableS3CdcBackup, EnableEKS, EnableAwsBackup, …
-    # capability flags — set them here as needed; sensible defaults apply otherwise.
-  }
-
-  lifecycle { ignore_changes = [administration_role_arn] }
-}
-
-resource "aws_cloudformation_stack_set_instance" "eon_source_members" {
-  stack_set_name = aws_cloudformation_stack_set.eon_source_members.name
-
-  deployment_targets {
-    organizational_unit_ids = var.organizational_unit_ids
-  }
-
-  region = var.aws_region
-}
-
-# (1, cont.) Register each OU with Eon, only after member roles are being deployed.
-resource "eon_source_aws_organizational_unit" "this" {
-  for_each = var.organizational_unit_ids
-
-  role_arn                        = aws_iam_role.eon_org_unit.arn
-  provider_organizational_unit_id = each.value
-
-  depends_on = [aws_cloudformation_stack_set_instance.eon_source_members]
 }

--- a/internal/provider/resource_source_aws_organizational_unit.go
+++ b/internal/provider/resource_source_aws_organizational_unit.go
@@ -44,7 +44,8 @@ func (r *SourceAwsOrganizationalUnitResource) Metadata(ctx context.Context, req 
 
 func (r *SourceAwsOrganizationalUnitResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Connects a source AWS organizational unit to the Eon project. All AWS accounts within the organizational unit (and its nested OUs) will be automatically discovered and available for backup.",
+		MarkdownDescription: "Connects a source AWS organizational unit to the Eon project. All AWS accounts within the organizational unit (and its nested OUs) are automatically discovered and available for backup.\n\n" +
+			"**Prerequisite:** connecting an OU only makes Eon discover member accounts and assume a role named `EonSourceAccountRole` in each one — it does not create that role. You must separately deploy `EonSourceAccountRole` into every member account, normally via a service-managed CloudFormation StackSet that auto-deploys to the OU (see the example). Without it, member accounts are discovered but have no permissions.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,

--- a/modules/aws-ou-onboarding/README.md
+++ b/modules/aws-ou-onboarding/README.md
@@ -1,0 +1,93 @@
+# aws-ou-onboarding module
+
+Onboards one or more AWS Organizational Units to Eon **completely** — both halves
+of the operation, so member accounts actually end up with permissions.
+
+Connecting an OU to Eon only makes Eon **discover** the member accounts and
+**assume** a role (`EonSourceAccountRole`) in each. It does **not** create that
+role. The bare `eon_source_aws_organizational_unit` resource does only the
+registration; used on its own it leaves every member account discovered but
+without an Eon role — the most common OU onboarding failure.
+
+This module does both parts:
+
+1. Registers each OU with Eon (`eon_source_aws_organizational_unit`).
+2. Creates `EonSourceAccountRole` in every member account via a service-managed
+   CloudFormation **StackSet** with auto-deployment, so current **and future**
+   accounts in the OU are covered. (Optionally) creates the management-account
+   discovery role too.
+
+It is the Terraform equivalent of Eon's official `aws-organization.yml`
+CloudFormation onboarding.
+
+## Prerequisite
+
+Enable CloudFormation trusted access with AWS Organizations once, in the
+management account, or the `SERVICE_MANAGED` StackSet cannot be created:
+
+```sh
+aws cloudformation activate-organizations-access
+```
+
+(or Console → CloudFormation → StackSets → "Activate trusted access").
+
+## Usage
+
+```hcl
+provider "aws" {
+  region = "us-east-1"
+  # credentials for the AWS Organization management account
+}
+
+provider "eon" {
+  endpoint      = "https://<tenant>.console.eon.io"
+  client_id     = var.eon_client_id
+  client_secret = var.eon_client_secret
+  project_id    = var.eon_project_id
+}
+
+module "eon_ou_onboarding" {
+  source = "github.com/eon-io/terraform-provider-eon//modules/aws-ou-onboarding"
+
+  eon_account_id      = "fde6adb5-38bc-45a3-919e-bd9ee17d9ba4"
+  scanning_account_id = "388762879875"
+
+  organizational_unit_ids = [
+    "ou-abc1-23456789",
+    "ou-abc1-98765432",
+  ]
+
+  # Optional: turn off capabilities you don't want the member role to grant.
+  capability_flags = {
+    EnableEKS = "false"
+  }
+}
+```
+
+If you already manage the management-account discovery role yourself, pass its
+ARN and the module will skip creating one:
+
+```hcl
+  discovery_role_arn = aws_iam_role.my_existing_eon_org_role.arn
+```
+
+## What gets created
+
+| Resource | Where | Purpose |
+|----------|-------|---------|
+| `aws_iam_role.discovery` (optional) | management account | role Eon assumes to enumerate the OU |
+| `aws_cloudformation_stack_set.source_members` | management account | defines the member-role deployment |
+| `aws_cloudformation_stack_set_instance.source_members` | OU members | creates `EonSourceAccountRole` in each account |
+| `eon_source_aws_organizational_unit.this` | Eon | registers each OU for discovery |
+
+## Inputs
+
+See `variables.tf`. Required: `eon_account_id`, `scanning_account_id`,
+`organizational_unit_ids`. Everything else has a sensible default.
+
+## Notes
+
+- The StackSet does not target the management account itself (service-managed
+  StackSets only deploy to members) — correct, since Eon does not scan it.
+- New accounts joining a registered OU automatically receive the role
+  (`auto_deployment.enabled = true`); no re-apply needed.

--- a/modules/aws-ou-onboarding/main.tf
+++ b/modules/aws-ou-onboarding/main.tf
@@ -1,0 +1,133 @@
+# Complete AWS Organizational Unit onboarding for Eon.
+#
+# Onboarding an OU is a TWO-part operation and this module does both:
+#
+#   1. Register each OU with Eon (eon_source_aws_organizational_unit). Eon then
+#      DISCOVERS the member accounts and ASSUMES `source_role_name` in each.
+#   2. CREATE that role in every member account, via a service-managed
+#      CloudFormation StackSet that auto-deploys to the OU (and to accounts that
+#      later join it).
+#
+# Doing only (1) — which is all the bare eon_source_aws_organizational_unit
+# resource does — leaves members discovered but with no permissions. This module
+# is the Terraform equivalent of Eon's official aws-organization.yml onboarding.
+#
+# PREREQUISITE (one-time, in the management account): enable CloudFormation
+# trusted access with AWS Organizations, or the SERVICE_MANAGED StackSet cannot
+# be created:
+#   aws cloudformation activate-organizations-access
+
+locals {
+  create_discovery_role = var.discovery_role_arn == null
+  discovery_role_arn    = local.create_discovery_role ? aws_iam_role.discovery[0].arn : var.discovery_role_arn
+
+  permissions_boundary = trimspace(var.permissions_boundary_name)
+
+  base_parameters = {
+    EonAccountId            = var.eon_account_id
+    RoleName                = var.source_role_name
+    ServiceAccountId        = var.service_account_id
+    ServiceDRAccountId      = var.service_dr_account_id
+    ScanningAccountId       = var.scanning_account_id
+    PermissionsBoundaryName = local.permissions_boundary
+  }
+
+  # Caller-supplied capability flags (EnableEKS, EnableS3CdcBackup, …) win over
+  # the base set; anything omitted falls back to the template's own defaults.
+  stackset_parameters = merge(local.base_parameters, var.capability_flags)
+}
+
+# (1) Management-account discovery role — created only when the caller did not
+# pass an existing discovery_role_arn.
+resource "aws_iam_role" "discovery" {
+  count = local.create_discovery_role ? 1 : 0
+  name  = var.discovery_role_name
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { AWS = [var.service_account_id, var.service_dr_account_id] }
+        Action    = "sts:AssumeRole"
+        Condition = { StringEquals = { "sts:ExternalId" = var.eon_account_id } }
+      },
+      {
+        Effect    = "Allow"
+        Principal = { AWS = ["arn:aws:iam::${var.service_account_id}:root", "arn:aws:iam::${var.service_dr_account_id}:root"] }
+        Action    = "sts:TagSession"
+      },
+    ]
+  })
+
+  inline_policy {
+    name = "${var.discovery_role_name}Policy"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          # Enumerate the OU hierarchy and member accounts.
+          Effect = "Allow"
+          Action = [
+            "organizations:ListAccounts",
+            "organizations:ListAccountsForParent",
+            "organizations:DescribeOrganizationalUnit",
+            "organizations:ListChildren",
+            "organizations:DescribeAccount",
+            "organizations:ListParents",
+            "organizations:ListOrganizationalUnitsForParent",
+          ]
+          Resource = "*"
+        },
+        {
+          # Assume the per-member source role. Role name is constrained; the
+          # account segment is a wildcard because the OU may hold any accounts.
+          Effect   = "Allow"
+          Action   = "sts:AssumeRole"
+          Resource = "arn:aws:iam::*:role/${var.source_role_name}"
+        },
+      ]
+    })
+  }
+}
+
+# (2) Create source_role_name in every member account of the OUs.
+resource "aws_cloudformation_stack_set" "source_members" {
+  name             = "EonSourceAccountOrgDeployment"
+  description      = "Deploys ${var.source_role_name} into Eon-onboarded OU member accounts"
+  permission_model = "SERVICE_MANAGED"
+  capabilities     = ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"]
+  template_url     = var.source_account_template_url
+
+  auto_deployment {
+    enabled                          = true
+    retain_stacks_on_account_removal = false
+  }
+
+  managed_execution { active = true }
+
+  parameters = local.stackset_parameters
+
+  lifecycle { ignore_changes = [administration_role_arn] }
+}
+
+resource "aws_cloudformation_stack_set_instance" "source_members" {
+  stack_set_name = aws_cloudformation_stack_set.source_members.name
+
+  deployment_targets {
+    organizational_unit_ids = var.organizational_unit_ids
+  }
+
+  region = var.aws_region
+}
+
+# (1, cont.) Register each OU with Eon, only after member roles are deploying, so
+# discovery doesn't transiently report missing permissions.
+resource "eon_source_aws_organizational_unit" "this" {
+  for_each = var.organizational_unit_ids
+
+  role_arn                        = local.discovery_role_arn
+  provider_organizational_unit_id = each.value
+
+  depends_on = [aws_cloudformation_stack_set_instance.source_members]
+}

--- a/modules/aws-ou-onboarding/outputs.tf
+++ b/modules/aws-ou-onboarding/outputs.tf
@@ -1,0 +1,26 @@
+output "discovery_role_arn" {
+  description = "ARN of the management-account role Eon assumes to enumerate the OU."
+  value       = local.discovery_role_arn
+}
+
+output "stack_set_name" {
+  description = "Name of the CloudFormation StackSet that deploys the source role into member accounts."
+  value       = aws_cloudformation_stack_set.source_members.name
+}
+
+output "stack_set_id" {
+  description = "ID of the CloudFormation StackSet."
+  value       = aws_cloudformation_stack_set.source_members.stack_set_id
+}
+
+output "organizational_units" {
+  description = "Map of OU ID => Eon registration details."
+  value = {
+    for ou_id, ou in eon_source_aws_organizational_unit.this : ou_id => {
+      id                             = ou.id
+      name                           = ou.name
+      status                         = ou.status
+      provider_management_account_id = ou.provider_management_account_id
+    }
+  }
+}

--- a/modules/aws-ou-onboarding/variables.tf
+++ b/modules/aws-ou-onboarding/variables.tf
@@ -1,0 +1,78 @@
+variable "eon_account_id" {
+  type        = string
+  description = "Eon-registered account ID, used as the STS ExternalId (confused-deputy guard) on every Eon role."
+}
+
+variable "organizational_unit_ids" {
+  type        = set(string)
+  description = "AWS Organizational Unit IDs to onboard (e.g. ou-abc1-23456789). All current and future member accounts in each OU (and nested OUs) are covered."
+
+  validation {
+    condition     = length(var.organizational_unit_ids) > 0
+    error_message = "Provide at least one organizational unit ID."
+  }
+}
+
+variable "aws_region" {
+  type        = string
+  description = "Region in which the member-account roles are created by the StackSet."
+  default     = "us-east-1"
+}
+
+variable "discovery_role_arn" {
+  type        = string
+  description = "ARN of an existing management-account role Eon assumes to enumerate the OU. Leave null to have this module create EonOrgUnitRole for you."
+  default     = null
+}
+
+variable "discovery_role_name" {
+  type        = string
+  description = "Name of the management-account discovery role this module creates when discovery_role_arn is null."
+  default     = "EonOrgUnitRole"
+}
+
+variable "source_role_name" {
+  type        = string
+  description = "Name of the per-member-account role Eon assumes to back up resources. Must match the role the StackSet creates."
+  default     = "EonSourceAccountRole"
+}
+
+variable "service_account_id" {
+  type        = string
+  description = "Eon service account ID (trusted principal on the roles)."
+  default     = "058264520728"
+}
+
+variable "service_dr_account_id" {
+  type        = string
+  description = "Eon service DR account ID (trusted principal on the roles)."
+  default     = "010438478826"
+}
+
+variable "scanning_account_id" {
+  type        = string
+  description = "Eon scanning account ID (12 digits)."
+
+  validation {
+    condition     = can(regex("^[0-9]{12}$", var.scanning_account_id))
+    error_message = "scanning_account_id must be a 12-digit AWS account ID."
+  }
+}
+
+variable "permissions_boundary_name" {
+  type        = string
+  description = "Optional IAM permissions boundary policy name applied to the member roles. Must exist with this exact name in every target account. Empty string disables it."
+  default     = ""
+}
+
+variable "source_account_template_url" {
+  type        = string
+  description = "URL of the Eon-hosted source-account CloudFormation template the StackSet deploys into each member account."
+  default     = "https://eon-public-b2b628cc-1d96-4fda-8dae-c3b1ad3ea03b.s3.amazonaws.com/source-account.yml"
+}
+
+variable "capability_flags" {
+  type        = map(string)
+  description = "Optional overrides for source-account.yml capability parameters (e.g. { EnableEKS = \"false\" }). Anything omitted uses the template default. Values must be the strings \"true\"/\"false\"."
+  default     = {}
+}

--- a/modules/aws-ou-onboarding/versions.tf
+++ b/modules/aws-ou-onboarding/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    eon = {
+      source  = "eon-io/eon"
+      version = ">= 2.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Onboarding an AWS Organizational Unit to Eon is a **two-part** operation: (1) register the OU, after which Eon discovers member accounts and assumes `EonSourceAccountRole` in each, and (2) actually create that role in every member account. Registration does **not** create the role. The provider previously exposed only part (1) via `eon_source_aws_organizational_unit`, and the example showed only that resource — so customers onboarded an OU and ended up with member accounts that have no Eon permissions (root cause of EON-12736, Creditsafe).

## Changes

- **`modules/aws-ou-onboarding/`** (new) — a module that does both parts: registers each OU **and** deploys `EonSourceAccountRole` into every member account via a service-managed, auto-deploying CloudFormation StackSet (and optionally creates the management-account discovery role). It is the Terraform equivalent of Eon's official `aws-organization.yml` onboarding. New accounts joining a registered OU are covered automatically. README + inputs/outputs included.
- **`examples/resources/eon_source_aws_organizational_unit/resource.tf`** — slimmed to the bare registration resource plus a prominent pointer to the module as the supported, complete onboarding path.
- **`internal/provider/resource_source_aws_organizational_unit.go`** — added a **Prerequisite** note to the resource `MarkdownDescription` explaining registration alone does not create member roles.
- **`docs/resources/source_aws_organizational_unit.md`** — regenerated via `make docs`.

No provider logic change. `go build` passes, `terraform validate` passes for the module, docs regenerate cleanly.

## Related

Backend safety net (surfaces members whose role is missing as `INSUFFICIENT_PERMISSIONS` regardless of onboarding method): eon-io/eon-service#34665.

Linear: EON-12736

🤖 Generated with [Claude Code](https://claude.com/claude-code)