### PR TITLE
feat(restore): add restore AWS organizational unit resource + data source stubs (EON-1702)

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -405,6 +406,72 @@ func (c *EonClient) DisconnectSourceAwsOrganizationalUnit(ctx context.Context, o
 	}
 
 	return nil
+}
+
+// errRestoreOUNotImplemented is returned by the restore AWS organizational unit
+// client stubs below.
+//
+// TODO(EON-1702): the restore AWS organizational unit endpoints
+// (connect/list/reconnect/disconnect) were just made public in eon-service but
+// eon-sdk-go has not been regenerated yet, so the AccountsAPI bindings and
+// request/response models do not exist. Once the SDK is bumped, wire these
+// methods to c.client.AccountsAPI.{Connect,List,Reconnect,Disconnect}RestoreAwsOrganizationalUnit
+// exactly like the source variants above, and drop the placeholder types.
+var errRestoreOUNotImplemented = errors.New("restore AWS organizational unit support is not yet implemented: pending eon-sdk-go regeneration (EON-1702)")
+
+// ConnectRestoreAwsOrganizationalUnitRequest is a placeholder mirroring the
+// source variant until the generated SDK type exists.
+//
+// TODO(EON-1702): replace with externalEonSdkAPI.ConnectRestoreAwsOrganizationalUnitRequest.
+type ConnectRestoreAwsOrganizationalUnitRequest struct {
+	RoleArn                      string
+	ProviderOrganizationalUnitId string
+}
+
+// RestoreAwsOrganizationalUnit is a placeholder mirroring the source variant
+// until the generated SDK type exists.
+//
+// TODO(EON-1702): replace with externalEonSdkAPI.RestoreAwsOrganizationalUnit.
+type RestoreAwsOrganizationalUnit struct {
+	Id                           string
+	Name                         string
+	RoleArn                      string
+	ProviderOrganizationalUnitId string
+	ProviderManagementAccountId  string
+	Status                       string
+}
+
+// ListRestoreAwsOrganizationalUnits retrieves all restore AWS organizational
+// units for the project.
+//
+// TODO(EON-1702): implement against AccountsAPI.ListRestoreAwsOrganizationalUnits
+// with pagination, mirroring ListSourceAwsOrganizationalUnits.
+func (c *EonClient) ListRestoreAwsOrganizationalUnits(ctx context.Context) ([]RestoreAwsOrganizationalUnit, error) {
+	return nil, errRestoreOUNotImplemented
+}
+
+// ConnectRestoreAwsOrganizationalUnit connects a new restore AWS organizational unit.
+//
+// TODO(EON-1702): implement against AccountsAPI.ConnectRestoreAwsOrganizationalUnit,
+// mirroring ConnectSourceAwsOrganizationalUnit.
+func (c *EonClient) ConnectRestoreAwsOrganizationalUnit(ctx context.Context, req ConnectRestoreAwsOrganizationalUnitRequest) (*RestoreAwsOrganizationalUnit, error) {
+	return nil, errRestoreOUNotImplemented
+}
+
+// ReconnectRestoreAwsOrganizationalUnit reconnects a previously disconnected
+// restore AWS organizational unit.
+//
+// TODO(EON-1702): implement against AccountsAPI.ReconnectRestoreAwsOrganizationalUnit.
+func (c *EonClient) ReconnectRestoreAwsOrganizationalUnit(ctx context.Context, organizationalUnitId string) (*RestoreAwsOrganizationalUnit, error) {
+	return nil, errRestoreOUNotImplemented
+}
+
+// DisconnectRestoreAwsOrganizationalUnit disconnects a restore AWS organizational unit.
+//
+// TODO(EON-1702): implement against AccountsAPI.DisconnectRestoreAwsOrganizationalUnit,
+// mirroring DisconnectSourceAwsOrganizationalUnit.
+func (c *EonClient) DisconnectRestoreAwsOrganizationalUnit(ctx context.Context, organizationalUnitId string) error {
+	return errRestoreOUNotImplemented
 }
 
 // ConnectRestoreAccount connects a new restore account

--- a/internal/provider/data_source_restore_aws_organizational_units.go
+++ b/internal/provider/data_source_restore_aws_organizational_units.go
@@ -1,0 +1,120 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/eon-io/terraform-provider-eon/internal/client"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &RestoreAwsOrganizationalUnitsDataSource{}
+
+func NewRestoreAwsOrganizationalUnitsDataSource() datasource.DataSource {
+	return &RestoreAwsOrganizationalUnitsDataSource{}
+}
+
+type RestoreAwsOrganizationalUnitsDataSource struct {
+	client *client.EonClient
+}
+
+type RestoreAwsOrganizationalUnitsDataSourceModel struct {
+	OrganizationalUnits []RestoreAwsOrganizationalUnitModel `tfsdk:"organizational_units"`
+}
+
+type RestoreAwsOrganizationalUnitModel struct {
+	Id                           types.String `tfsdk:"id"`
+	Name                         types.String `tfsdk:"name"`
+	RoleArn                      types.String `tfsdk:"role_arn"`
+	ProviderOrganizationalUnitId types.String `tfsdk:"provider_organizational_unit_id"`
+	ProviderManagementAccountId  types.String `tfsdk:"provider_management_account_id"`
+	Status                       types.String `tfsdk:"status"`
+}
+
+func (d *RestoreAwsOrganizationalUnitsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_restore_aws_organizational_units"
+}
+
+func (d *RestoreAwsOrganizationalUnitsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Retrieves a list of restore AWS organizational units for the Eon project.",
+		Attributes: map[string]schema.Attribute{
+			"organizational_units": schema.ListNestedAttribute{
+				MarkdownDescription: "List of restore AWS organizational units.",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							MarkdownDescription: "Eon-assigned organizational unit ID.",
+							Computed:            true,
+						},
+						"name": schema.StringAttribute{
+							MarkdownDescription: "The organizational unit display name in Eon.",
+							Computed:            true,
+						},
+						"role_arn": schema.StringAttribute{
+							MarkdownDescription: "ARN of the role Eon assumes to access the organizational unit in AWS.",
+							Computed:            true,
+						},
+						"provider_organizational_unit_id": schema.StringAttribute{
+							MarkdownDescription: "AWS Organizational Unit ID.",
+							Computed:            true,
+						},
+						"provider_management_account_id": schema.StringAttribute{
+							MarkdownDescription: "AWS Organization management account ID.",
+							Computed:            true,
+						},
+						"status": schema.StringAttribute{
+							MarkdownDescription: "Connection status of the AWS organizational unit. Possible values: `CONNECTED`, `DISCONNECTED`, `INSUFFICIENT_PERMISSIONS`.",
+							Computed:            true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *RestoreAwsOrganizationalUnitsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	c, ok := req.ProviderData.(*client.EonClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *client.EonClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = c
+}
+
+func (d *RestoreAwsOrganizationalUnitsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data RestoreAwsOrganizationalUnitsDataSourceModel
+
+	ous, err := d.client.ListRestoreAwsOrganizationalUnits(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read restore AWS organizational units: %s", err))
+		return
+	}
+
+	for _, ou := range ous {
+		ouModel := RestoreAwsOrganizationalUnitModel{
+			Id:                           types.StringValue(ou.Id),
+			Name:                         types.StringValue(ou.Name),
+			RoleArn:                      types.StringValue(ou.RoleArn),
+			ProviderOrganizationalUnitId: types.StringValue(ou.ProviderOrganizationalUnitId),
+			ProviderManagementAccountId:  types.StringValue(ou.ProviderManagementAccountId),
+			Status:                       types.StringValue(ou.Status),
+		}
+
+		data.OrganizationalUnits = append(data.OrganizationalUnits, ouModel)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -175,6 +175,7 @@ func (p *EonProvider) Resources(ctx context.Context) []func() resource.Resource 
 	return []func() resource.Resource{
 		NewSourceAccountResource,
 		NewSourceAwsOrganizationalUnitResource,
+		NewRestoreAwsOrganizationalUnitResource,
 		NewRestoreAccountResource,
 		NewRestoreAccountConnectivityConfigResource,
 		NewRestoreJobResource,
@@ -190,6 +191,7 @@ func (p *EonProvider) DataSources(ctx context.Context) []func() datasource.DataS
 	return []func() datasource.DataSource{
 		NewSourceAccountsDataSource,
 		NewSourceAwsOrganizationalUnitsDataSource,
+		NewRestoreAwsOrganizationalUnitsDataSource,
 		NewRestoreAccountsDataSource,
 		NewSnapshotDataSource,
 		NewBackupPoliciesDataSource,

--- a/internal/provider/resource_restore_aws_organizational_unit.go
+++ b/internal/provider/resource_restore_aws_organizational_unit.go
@@ -1,0 +1,255 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/eon-io/terraform-provider-eon/internal/client"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ resource.Resource = &RestoreAwsOrganizationalUnitResource{}
+var _ resource.ResourceWithImportState = &RestoreAwsOrganizationalUnitResource{}
+
+func NewRestoreAwsOrganizationalUnitResource() resource.Resource {
+	return &RestoreAwsOrganizationalUnitResource{}
+}
+
+type RestoreAwsOrganizationalUnitResource struct {
+	client *client.EonClient
+}
+
+type RestoreAwsOrganizationalUnitResourceModel struct {
+	Id                           types.String `tfsdk:"id"`
+	Name                         types.String `tfsdk:"name"`
+	RoleArn                      types.String `tfsdk:"role_arn"`
+	ProviderOrganizationalUnitId types.String `tfsdk:"provider_organizational_unit_id"`
+	ProviderManagementAccountId  types.String `tfsdk:"provider_management_account_id"`
+	Status                       types.String `tfsdk:"status"`
+	CreatedAt                    types.String `tfsdk:"created_at"`
+	UpdatedAt                    types.String `tfsdk:"updated_at"`
+}
+
+func (r *RestoreAwsOrganizationalUnitResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_restore_aws_organizational_unit"
+}
+
+func (r *RestoreAwsOrganizationalUnitResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Connects a restore AWS organizational unit to the Eon project as a restore target. All current and future descendant AWS accounts within the organizational unit are discovered and available as restore accounts.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Eon-assigned organizational unit ID.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "The organizational unit display name in Eon.",
+				Computed:            true,
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"role_arn": schema.StringAttribute{
+				MarkdownDescription: "ARN of the role Eon assumes to access the organizational unit in AWS.",
+				Required:            true,
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"provider_organizational_unit_id": schema.StringAttribute{
+				MarkdownDescription: "AWS Organizational Unit ID.",
+				Required:            true,
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"provider_management_account_id": schema.StringAttribute{
+				MarkdownDescription: "AWS Organization management account ID.",
+				Computed:            true,
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"status": schema.StringAttribute{
+				MarkdownDescription: "Connection status of the AWS organizational unit. Possible values: `CONNECTED`, `DISCONNECTED`, `INSUFFICIENT_PERMISSIONS`.",
+				Computed:            true,
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"created_at": schema.StringAttribute{
+				MarkdownDescription: "Date and time the restore AWS organizational unit was connected to the Eon project.",
+				Computed:            true,
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"updated_at": schema.StringAttribute{
+				MarkdownDescription: "Date and time the restore AWS organizational unit was last updated.",
+				Computed:            true,
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+		},
+	}
+}
+
+func (r *RestoreAwsOrganizationalUnitResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	c, ok := req.ProviderData.(*client.EonClient)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type", fmt.Sprintf("Expected *client.EonClient, got: %T", req.ProviderData))
+		return
+	}
+
+	r.client = c
+}
+
+func (r *RestoreAwsOrganizationalUnitResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data RestoreAwsOrganizationalUnitResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	connectReq := client.ConnectRestoreAwsOrganizationalUnitRequest{
+		RoleArn:                      data.RoleArn.ValueString(),
+		ProviderOrganizationalUnitId: data.ProviderOrganizationalUnitId.ValueString(),
+	}
+
+	tflog.Debug(ctx, "Connecting restore AWS organizational unit", map[string]interface{}{
+		"role_arn":                        data.RoleArn.ValueString(),
+		"provider_organizational_unit_id": data.ProviderOrganizationalUnitId.ValueString(),
+	})
+
+	ou, err := r.client.ConnectRestoreAwsOrganizationalUnit(ctx, connectReq)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to connect restore AWS organizational unit: %s", err))
+		return
+	}
+
+	data.Id = types.StringValue(ou.Id)
+	data.Name = types.StringValue(ou.Name)
+	data.RoleArn = types.StringValue(ou.RoleArn)
+	data.ProviderOrganizationalUnitId = types.StringValue(ou.ProviderOrganizationalUnitId)
+	data.ProviderManagementAccountId = types.StringValue(ou.ProviderManagementAccountId)
+	data.Status = types.StringValue(ou.Status)
+	data.CreatedAt = types.StringValue(time.Now().Format(time.RFC3339))
+	data.UpdatedAt = types.StringValue(time.Now().Format(time.RFC3339))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *RestoreAwsOrganizationalUnitResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data RestoreAwsOrganizationalUnitResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ous, err := r.client.ListRestoreAwsOrganizationalUnits(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read restore AWS organizational units: %s", err))
+		return
+	}
+
+	var found bool
+	for _, ou := range ous {
+		if ou.Id == data.Id.ValueString() {
+			found = true
+			data.Name = types.StringValue(ou.Name)
+			data.RoleArn = types.StringValue(ou.RoleArn)
+			data.ProviderOrganizationalUnitId = types.StringValue(ou.ProviderOrganizationalUnitId)
+			data.ProviderManagementAccountId = types.StringValue(ou.ProviderManagementAccountId)
+			data.Status = types.StringValue(ou.Status)
+
+			if data.CreatedAt.IsNull() || data.CreatedAt.IsUnknown() {
+				data.CreatedAt = types.StringValue(time.Now().Format(time.RFC3339))
+			}
+			if data.UpdatedAt.IsNull() || data.UpdatedAt.IsUnknown() {
+				data.UpdatedAt = types.StringValue(time.Now().Format(time.RFC3339))
+			}
+
+			break
+		}
+	}
+
+	if !found {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *RestoreAwsOrganizationalUnitResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data RestoreAwsOrganizationalUnitResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.AddWarning("Update Not Supported", "Most restore AWS organizational unit changes require replacement. Please update your configuration to force replacement if needed.")
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *RestoreAwsOrganizationalUnitResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data RestoreAwsOrganizationalUnitResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Disconnecting restore AWS organizational unit", map[string]interface{}{
+		"id": data.Id.ValueString(),
+	})
+
+	err := r.client.DisconnectRestoreAwsOrganizationalUnit(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to disconnect restore AWS organizational unit: %s", err))
+		return
+	}
+}
+
+func (r *RestoreAwsOrganizationalUnitResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+
+	ous, err := r.client.ListRestoreAwsOrganizationalUnits(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read restore AWS organizational units during import: %s", err))
+		return
+	}
+
+	var found bool
+	var data RestoreAwsOrganizationalUnitResourceModel
+
+	for _, ou := range ous {
+		if ou.Id == req.ID {
+			found = true
+
+			data.Id = types.StringValue(ou.Id)
+			data.Name = types.StringValue(ou.Name)
+			data.RoleArn = types.StringValue(ou.RoleArn)
+			data.ProviderOrganizationalUnitId = types.StringValue(ou.ProviderOrganizationalUnitId)
+			data.ProviderManagementAccountId = types.StringValue(ou.ProviderManagementAccountId)
+			data.Status = types.StringValue(ou.Status)
+			data.CreatedAt = types.StringValue(time.Now().Format(time.RFC3339))
+			data.UpdatedAt = types.StringValue(time.Now().Format(time.RFC3339))
+
+			break
+		}
+	}
+
+	if !found {
+		resp.Diagnostics.AddError(
+			"Resource Not Found",
+			fmt.Sprintf("Restore AWS organizational unit with ID %s not found", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}


### PR DESCRIPTION
## What

Adds a Terraform resource and data source for **restore** AWS organizational units, mirroring the existing **source** AWS OU equivalents. This tracks the eon-service change (PR eon-io/eon-service#35111) that made the restore AWS OU endpoints (connect / list / reconnect / disconnect) user-facing.

### New
- `eon_restore_aws_organizational_unit` resource (Create/Read/Update/Delete/ImportState)
- `eon_restore_aws_organizational_units` data source
- `EonClient` methods: `ConnectRestoreAwsOrganizationalUnit`, `ListRestoreAwsOrganizationalUnits`, `ReconnectRestoreAwsOrganizationalUnit`, `DisconnectRestoreAwsOrganizationalUnit`
- Registered both in `provider.go`

### Stubs
`eon-sdk-go` has not been regenerated from the now-public endpoints, so it has no restore AWS OU bindings or models yet. The client methods are therefore **stubs**:
- Return a sentinel `errRestoreOUNotImplemented`.
- Use placeholder `ConnectRestoreAwsOrganizationalUnitRequest` / `RestoreAwsOrganizationalUnit` types.

All marked `TODO(EON-1702)` to wire to the generated `AccountsAPI.*RestoreAwsOrganizationalUnit` bindings and drop the placeholders once the SDK is bumped.

Builds, vets, and gofmt-clean.

## Linear

EON-1702

🤖 Generated with [Claude Code](https://claude.com/claude-code)