### PR TITLE
chore: bump eon-sdk-go to v1.147.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.4
 
 require (
-	github.com/eon-io/eon-sdk-go v1.139.0
+	github.com/eon-io/eon-sdk-go v1.147.0
 	github.com/hashicorp/terraform-plugin-docs v0.24.0
 	github.com/hashicorp/terraform-plugin-framework v1.13.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/eon-io/eon-sdk-go v1.139.0 h1:1yGXZoiWNcpkapYv3OpiYiuk25VC+pTjGdz/tjzkGPA=
-github.com/eon-io/eon-sdk-go v1.139.0/go.mod h1:NWrS3rllESPQ7vzryT7+bHkOpNrXbXcnRtaPlv0LScw=
+github.com/eon-io/eon-sdk-go v1.147.0 h1:JCT6T1RQbpvGEEftUcuB9NYJiYmAtAyvRn+yFcFtgx4=
+github.com/eon-io/eon-sdk-go v1.147.0/go.mod h1:NWrS3rllESPQ7vzryT7+bHkOpNrXbXcnRtaPlv0LScw=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -555,6 +555,31 @@ func (c *EonClient) GetRestoreJob(ctx context.Context, jobId string) (*externalE
 	return &job, nil
 }
 
+// restoreJobIDFromResponse interprets the response from a restore endpoint that
+// may be intercepted by a Multi-Party Approval (MPA) policy. On HTTP 202 the
+// restore job started and its ID is read from the response body. On HTTP 201 the
+// operation was intercepted by an MPA policy and cannot proceed without approval.
+func restoreJobIDFromResponse(resp *externalEonSdkAPI.MPAInterceptedResponse, httpResp *http.Response, action string) (string, error) {
+	switch httpResp.StatusCode {
+	case http.StatusAccepted:
+		body, err := io.ReadAll(httpResp.Body)
+		if err != nil {
+			return "", fmt.Errorf("%s: failed to read response body: %w", action, err)
+		}
+		var initiation externalEonSdkAPI.RestoreJobInitiationResponse
+		if err := json.Unmarshal(body, &initiation); err != nil {
+			return "", fmt.Errorf("%s: failed to parse response: %w", action, err)
+		}
+		return initiation.GetJobId(), nil
+	case http.StatusCreated:
+		mpaReq := resp.GetMpaRequest()
+		return "", fmt.Errorf("%s: operation requires Multi-Party Approval (MPA request ID %q); approve the request and retry", action, mpaReq.GetId())
+	default:
+		body, _ := io.ReadAll(httpResp.Body)
+		return "", fmt.Errorf("API error %d: %s", httpResp.StatusCode, string(body))
+	}
+}
+
 // StartVolumeRestore starts a volume restore job
 func (c *EonClient) StartVolumeRestore(ctx context.Context, resourceId, snapshotId string, req externalEonSdkAPI.RestoreVolumeToEbsRequest) (string, error) {
 	if err := c.tokenRefresher.EnsureValidToken(); err != nil {
@@ -568,12 +593,7 @@ func (c *EonClient) StartVolumeRestore(ctx context.Context, resourceId, snapshot
 
 	defer httpResp.Body.Close()
 
-	if httpResp.StatusCode != http.StatusAccepted {
-		body, _ := io.ReadAll(httpResp.Body)
-		return "", fmt.Errorf("API error %d: %s", httpResp.StatusCode, string(body))
-	}
-
-	return resp.GetJobId(), nil
+	return restoreJobIDFromResponse(resp, httpResp, "failed to start volume restore")
 }
 
 // GetResourceById retrieves a resource by ID
@@ -611,12 +631,7 @@ func (c *EonClient) StartRdsRestore(ctx context.Context, resourceId, snapshotId 
 
 	defer httpResp.Body.Close()
 
-	if httpResp.StatusCode != http.StatusAccepted {
-		body, _ := io.ReadAll(httpResp.Body)
-		return "", fmt.Errorf("API error %d: %s", httpResp.StatusCode, string(body))
-	}
-
-	return resp.GetJobId(), nil
+	return restoreJobIDFromResponse(resp, httpResp, "failed to start RDS restore")
 }
 
 // StartEc2InstanceRestore starts an EC2 instance restore job
@@ -632,12 +647,7 @@ func (c *EonClient) StartEc2InstanceRestore(ctx context.Context, resourceId, sna
 
 	defer httpResp.Body.Close()
 
-	if httpResp.StatusCode != http.StatusAccepted {
-		body, _ := io.ReadAll(httpResp.Body)
-		return "", fmt.Errorf("API error %d: %s", httpResp.StatusCode, string(body))
-	}
-
-	return resp.GetJobId(), nil
+	return restoreJobIDFromResponse(resp, httpResp, "failed to start EC2 instance restore")
 }
 
 // StartS3BucketRestore starts an S3 bucket restore job
@@ -653,12 +663,7 @@ func (c *EonClient) StartS3BucketRestore(ctx context.Context, resourceId, snapsh
 
 	defer httpResp.Body.Close()
 
-	if httpResp.StatusCode != http.StatusAccepted {
-		body, _ := io.ReadAll(httpResp.Body)
-		return "", fmt.Errorf("API error %d: %s", httpResp.StatusCode, string(body))
-	}
-
-	return resp.GetJobId(), nil
+	return restoreJobIDFromResponse(resp, httpResp, "failed to start S3 bucket restore")
 }
 
 // StartS3FileRestore starts an S3 file restore job
@@ -695,12 +700,7 @@ func (c *EonClient) StartGcpVmInstanceRestore(ctx context.Context, resourceId, s
 
 	defer httpResp.Body.Close()
 
-	if httpResp.StatusCode != http.StatusAccepted {
-		body, _ := io.ReadAll(httpResp.Body)
-		return "", fmt.Errorf("API error %d: %s", httpResp.StatusCode, string(body))
-	}
-
-	return resp.GetJobId(), nil
+	return restoreJobIDFromResponse(resp, httpResp, "failed to start GCP VM instance restore")
 }
 
 // StartGcpDiskRestore starts a GCP disk restore job
@@ -716,12 +716,7 @@ func (c *EonClient) StartGcpDiskRestore(ctx context.Context, resourceId, snapsho
 
 	defer httpResp.Body.Close()
 
-	if httpResp.StatusCode != http.StatusAccepted {
-		body, _ := io.ReadAll(httpResp.Body)
-		return "", fmt.Errorf("API error %d: %s", httpResp.StatusCode, string(body))
-	}
-
-	return resp.GetJobId(), nil
+	return restoreJobIDFromResponse(resp, httpResp, "failed to start GCP disk restore")
 }
 
 // StartGcpCloudSqlRestore starts a GCP Cloud SQL restore job
@@ -737,12 +732,7 @@ func (c *EonClient) StartGcpCloudSqlRestore(ctx context.Context, resourceId, sna
 
 	defer httpResp.Body.Close()
 
-	if httpResp.StatusCode != http.StatusAccepted {
-		body, _ := io.ReadAll(httpResp.Body)
-		return "", fmt.Errorf("API error %d: %s", httpResp.StatusCode, string(body))
-	}
-
-	return resp.GetJobId(), nil
+	return restoreJobIDFromResponse(resp, httpResp, "failed to start GCP Cloud SQL restore")
 }
 
 // BigQueryRestoreDestination represents the destination for a BigQuery dataset restore


### PR DESCRIPTION
## Summary

Upgrade `eon-sdk-go` from `v1.139.0` to `v1.147.0` (latest).

## Breaking change handled

Seven restore endpoints (EBS volume, RDS, EC2, S3 bucket, GCP VM/disk/Cloud SQL) changed their typed return from `RestoreJobInitiationResponse` to `MPAInterceptedResponse` to support **Multi-Party Approval (MPA)**. These endpoints now respond:

- **202** — restore started, job ID in the response body
- **201** — intercepted by an MPA policy, requires approval before it runs

Added a `restoreJobIDFromResponse` helper in `internal/client/client.go` that:
- On **202**, re-reads the response body and decodes it into `RestoreJobInitiationResponse` to recover the job ID (preserves prior behavior).
- On **201**, returns a clear error noting the operation requires MPA approval, including the MPA request ID.
- Otherwise falls through to the existing generic API-error path.

`RestoreFiles` and other endpoints still returning the job-ID type are untouched.

## Note

The MPA interception is a real server-side behavior change. Restore operations covered by an MPA policy will now fail with a "requires Multi-Party Approval" error instead of starting a job, until approved.

## Testing

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)