### PR TITLE
feat(provider): use GET restore account endpoint for reads (EON-13193)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/eon-io/terraform-provider-eon
 go 1.25.8
 
 require (
-	github.com/eon-io/eon-sdk-go v1.147.0
+	github.com/eon-io/eon-sdk-go v1.160.0
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/eon-io/eon-sdk-go v1.147.0 h1:JCT6T1RQbpvGEEftUcuB9NYJiYmAtAyvRn+yFcFtgx4=
-github.com/eon-io/eon-sdk-go v1.147.0/go.mod h1:NWrS3rllESPQ7vzryT7+bHkOpNrXbXcnRtaPlv0LScw=
+github.com/eon-io/eon-sdk-go v1.160.0 h1:30eh1lGELyTOl9NsgI+dV1f2utwJ5PGjUcuUwsof+Xs=
+github.com/eon-io/eon-sdk-go v1.160.0/go.mod h1:NWrS3rllESPQ7vzryT7+bHkOpNrXbXcnRtaPlv0LScw=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -194,7 +194,7 @@ func (c *EonClient) GetRestoreAccount(ctx context.Context, accountId string) (*e
 	if apiErr := c.handleAPIError(err, httpResp, "failed to get restore account"); apiErr != nil {
 		return nil, apiErr
 	}
-	defer httpResp.Body.Close()
+	defer func() { _ = httpResp.Body.Close() }()
 
 	if httpResp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResp.Body)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -184,6 +184,30 @@ func (c *EonClient) ListRestoreAccounts(ctx context.Context) ([]externalEonSdkAP
 	return allAccounts, nil
 }
 
+// GetRestoreAccount retrieves a single restore account by ID.
+func (c *EonClient) GetRestoreAccount(ctx context.Context, accountId string) (*externalEonSdkAPI.RestoreAccount, error) {
+	if err := c.tokenRefresher.EnsureValidToken(); err != nil {
+		return nil, fmt.Errorf("failed to ensure valid token: %w", err)
+	}
+
+	resp, httpResp, err := c.client.AccountsAPI.GetRestoreAccount(ctx, c.projectID, accountId).Execute()
+	if apiErr := c.handleAPIError(err, httpResp, "failed to get restore account"); apiErr != nil {
+		return nil, apiErr
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(httpResp.Body)
+		return nil, &APIError{
+			StatusCode: httpResp.StatusCode,
+			Message:    string(body),
+		}
+	}
+
+	account := resp.GetRestoreAccount()
+	return &account, nil
+}
+
 // ConnectSourceAccount connects a new source account
 func (c *EonClient) ConnectSourceAccount(ctx context.Context, req externalEonSdkAPI.ConnectSourceAccountRequest) (*externalEonSdkAPI.SourceAccount, error) {
 	if err := c.tokenRefresher.EnsureValidToken(); err != nil {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -683,7 +683,7 @@ func restoreJobIDFromResponse(resp *externalEonSdkAPI.MPAInterceptedResponse, ht
 		}
 		return initiation.GetJobId(), nil
 	case http.StatusCreated:
-		mpaReq := resp.GetMpaRequest()
+		mpaReq := resp.GetActionApprovalRequest()
 		return "", fmt.Errorf("%s: operation requires Multi-Party Approval (MPA request ID %q); approve the request and retry", action, mpaReq.GetId())
 	default:
 		body, _ := io.ReadAll(httpResp.Body)

--- a/internal/provider/resource_restore_account.go
+++ b/internal/provider/resource_restore_account.go
@@ -277,77 +277,70 @@ func (r *RestoreAccountResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	accounts, err := r.client.ListRestoreAccounts(ctx)
+	account, err := r.client.GetRestoreAccount(ctx, data.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read restore accounts: %s", err))
-		return
-	}
-
-	var found bool
-	for _, account := range accounts {
-		if account.Id == data.Id.ValueString() {
-			found = true
-			data.Name = types.StringValue(account.GetName())
-			data.Status = types.StringValue(string(account.Status))
-			data.ProviderAccountId = types.StringValue(account.GetProviderAccountId())
-
-			cloudProvider := CloudProvider(account.RestoreAccountAttributes.GetCloudProvider())
-			data.CloudProvider = types.StringValue(cloudProvider.String())
-
-			// Populate cloud-specific blocks from API response
-			switch cloudProvider {
-			case CloudProviderAWS:
-				if account.RestoreAccountAttributes.HasAws() {
-					awsAttrs := account.RestoreAccountAttributes.GetAws()
-					data.Aws = &AwsAccountConfigModel{
-						RoleArn: types.StringValue(awsAttrs.GetRoleArn()),
-					}
-					// Also populate deprecated role field for backward compatibility
-					data.Role = types.StringValue(awsAttrs.GetRoleArn())
-				}
-				data.Azure = nil
-				data.Gcp = nil
-			case CloudProviderAzure:
-				if account.RestoreAccountAttributes.HasAzure() {
-					azureAttrs := account.RestoreAccountAttributes.GetAzure()
-					data.Azure = &AzureAccountConfigModel{
-						TenantId:       types.StringValue(azureAttrs.GetTenantId()),
-						SubscriptionId: types.StringValue(account.GetProviderAccountId()),
-					}
-					if azureAttrs.HasResourceGroupName() {
-						data.Azure.ResourceGroupName = types.StringValue(azureAttrs.GetResourceGroupName())
-					}
-				}
-				data.Aws = nil
-				data.Gcp = nil
-				data.Role = types.StringNull()
-			case CloudProviderGCP:
-				if account.RestoreAccountAttributes.HasGcp() {
-					gcpAttrs := account.RestoreAccountAttributes.GetGcp()
-					data.Gcp = &GcpAccountConfigModel{
-						ProjectId:      types.StringValue(account.GetProviderAccountId()),
-						ServiceAccount: types.StringValue(gcpAttrs.GetServiceAccount()),
-					}
-				}
-				data.Aws = nil
-				data.Azure = nil
-				data.Role = types.StringNull()
-			}
-
-			if data.CreatedAt.IsNull() || data.CreatedAt.IsUnknown() {
-				data.CreatedAt = types.StringValue(time.Now().Format(time.RFC3339))
-			}
-			if data.UpdatedAt.IsNull() || data.UpdatedAt.IsUnknown() {
-				data.UpdatedAt = types.StringValue(time.Now().Format(time.RFC3339))
-			}
-
-			break
+		// A deleted account returns 404 — drop it from state so Terraform plans a recreate.
+		var apiErr *client.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == 404 {
+			resp.State.RemoveResource(ctx)
+			return
 		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read restore account: %s", err))
+		return
 	}
 
-	if !found {
-		resp.State.RemoveResource(ctx)
-		return
+	data.Name = types.StringValue(account.GetName())
+	data.Status = types.StringValue(string(account.Status))
+	data.ProviderAccountId = types.StringValue(account.GetProviderAccountId())
+
+	cloudProvider := CloudProvider(account.RestoreAccountAttributes.GetCloudProvider())
+	data.CloudProvider = types.StringValue(cloudProvider.String())
+
+	// Populate cloud-specific blocks from API response
+	switch cloudProvider {
+	case CloudProviderAWS:
+		if account.RestoreAccountAttributes.HasAws() {
+			awsAttrs := account.RestoreAccountAttributes.GetAws()
+			data.Aws = &AwsAccountConfigModel{
+				RoleArn: types.StringValue(awsAttrs.GetRoleArn()),
+			}
+			// Also populate deprecated role field for backward compatibility
+			data.Role = types.StringValue(awsAttrs.GetRoleArn())
+		}
+		data.Azure = nil
+		data.Gcp = nil
+	case CloudProviderAzure:
+		if account.RestoreAccountAttributes.HasAzure() {
+			azureAttrs := account.RestoreAccountAttributes.GetAzure()
+			data.Azure = &AzureAccountConfigModel{
+				TenantId:       types.StringValue(azureAttrs.GetTenantId()),
+				SubscriptionId: types.StringValue(account.GetProviderAccountId()),
+			}
+			if azureAttrs.HasResourceGroupName() {
+				data.Azure.ResourceGroupName = types.StringValue(azureAttrs.GetResourceGroupName())
+			}
+		}
+		data.Aws = nil
+		data.Gcp = nil
+		data.Role = types.StringNull()
+	case CloudProviderGCP:
+		if account.RestoreAccountAttributes.HasGcp() {
+			gcpAttrs := account.RestoreAccountAttributes.GetGcp()
+			data.Gcp = &GcpAccountConfigModel{
+				ProjectId:      types.StringValue(account.GetProviderAccountId()),
+				ServiceAccount: types.StringValue(gcpAttrs.GetServiceAccount()),
+			}
+		}
+		data.Aws = nil
+		data.Azure = nil
+		data.Role = types.StringNull()
+	}
+
+	if data.CreatedAt.IsNull() || data.CreatedAt.IsUnknown() {
+		data.CreatedAt = types.StringValue(time.Now().Format(time.RFC3339))
+	}
+	if data.UpdatedAt.IsNull() || data.UpdatedAt.IsUnknown() {
+		data.UpdatedAt = types.StringValue(time.Now().Format(time.RFC3339))
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -403,72 +396,63 @@ func (r *RestoreAccountResource) Delete(ctx context.Context, req resource.Delete
 func (r *RestoreAccountResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 
-	accounts, err := r.client.ListRestoreAccounts(ctx)
+	account, err := r.client.GetRestoreAccount(ctx, req.ID)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read restore accounts during import: %s", err))
+		var apiErr *client.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == 404 {
+			resp.Diagnostics.AddError(
+				"Resource Not Found",
+				fmt.Sprintf("Restore account with ID %s not found", req.ID),
+			)
+			return
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read restore account during import: %s", err))
 		return
 	}
 
-	var found bool
 	var data RestoreAccountResourceModel
+	data.Id = types.StringValue(account.Id)
+	data.Name = types.StringValue(account.GetName())
+	data.Status = types.StringValue(string(account.Status))
+	data.ProviderAccountId = types.StringValue(account.GetProviderAccountId())
 
-	for _, account := range accounts {
-		if account.Id == req.ID {
-			found = true
-			data.Id = types.StringValue(account.Id)
-			data.Name = types.StringValue(account.GetName())
-			data.Status = types.StringValue(string(account.Status))
-			data.ProviderAccountId = types.StringValue(account.GetProviderAccountId())
+	cloudProvider := CloudProvider(account.RestoreAccountAttributes.GetCloudProvider())
+	data.CloudProvider = types.StringValue(cloudProvider.String())
 
-			cloudProvider := CloudProvider(account.RestoreAccountAttributes.GetCloudProvider())
-			data.CloudProvider = types.StringValue(cloudProvider.String())
-
-			// Populate cloud-specific blocks from API response
-			switch cloudProvider {
-			case CloudProviderAWS:
-				if account.RestoreAccountAttributes.HasAws() {
-					awsAttrs := account.RestoreAccountAttributes.GetAws()
-					data.Aws = &AwsAccountConfigModel{
-						RoleArn: types.StringValue(awsAttrs.GetRoleArn()),
-					}
-					// Also populate deprecated role field for backward compatibility
-					data.Role = types.StringValue(awsAttrs.GetRoleArn())
-				}
-			case CloudProviderAzure:
-				if account.RestoreAccountAttributes.HasAzure() {
-					azureAttrs := account.RestoreAccountAttributes.GetAzure()
-					data.Azure = &AzureAccountConfigModel{
-						TenantId:       types.StringValue(azureAttrs.GetTenantId()),
-						SubscriptionId: types.StringValue(account.GetProviderAccountId()),
-					}
-					if azureAttrs.HasResourceGroupName() {
-						data.Azure.ResourceGroupName = types.StringValue(azureAttrs.GetResourceGroupName())
-					}
-				}
-			case CloudProviderGCP:
-				if account.RestoreAccountAttributes.HasGcp() {
-					gcpAttrs := account.RestoreAccountAttributes.GetGcp()
-					data.Gcp = &GcpAccountConfigModel{
-						ProjectId:      types.StringValue(account.GetProviderAccountId()),
-						ServiceAccount: types.StringValue(gcpAttrs.GetServiceAccount()),
-					}
-				}
+	// Populate cloud-specific blocks from API response
+	switch cloudProvider {
+	case CloudProviderAWS:
+		if account.RestoreAccountAttributes.HasAws() {
+			awsAttrs := account.RestoreAccountAttributes.GetAws()
+			data.Aws = &AwsAccountConfigModel{
+				RoleArn: types.StringValue(awsAttrs.GetRoleArn()),
 			}
-
-			data.CreatedAt = types.StringValue(time.Now().Format(time.RFC3339))
-			data.UpdatedAt = types.StringValue(time.Now().Format(time.RFC3339))
-
-			break
+			// Also populate deprecated role field for backward compatibility
+			data.Role = types.StringValue(awsAttrs.GetRoleArn())
+		}
+	case CloudProviderAzure:
+		if account.RestoreAccountAttributes.HasAzure() {
+			azureAttrs := account.RestoreAccountAttributes.GetAzure()
+			data.Azure = &AzureAccountConfigModel{
+				TenantId:       types.StringValue(azureAttrs.GetTenantId()),
+				SubscriptionId: types.StringValue(account.GetProviderAccountId()),
+			}
+			if azureAttrs.HasResourceGroupName() {
+				data.Azure.ResourceGroupName = types.StringValue(azureAttrs.GetResourceGroupName())
+			}
+		}
+	case CloudProviderGCP:
+		if account.RestoreAccountAttributes.HasGcp() {
+			gcpAttrs := account.RestoreAccountAttributes.GetGcp()
+			data.Gcp = &GcpAccountConfigModel{
+				ProjectId:      types.StringValue(account.GetProviderAccountId()),
+				ServiceAccount: types.StringValue(gcpAttrs.GetServiceAccount()),
+			}
 		}
 	}
 
-	if !found {
-		resp.Diagnostics.AddError(
-			"Resource Not Found",
-			fmt.Sprintf("Restore account with ID %s not found", req.ID),
-		)
-		return
-	}
+	data.CreatedAt = types.StringValue(time.Now().Format(time.RFC3339))
+	data.UpdatedAt = types.StringValue(time.Now().Format(time.RFC3339))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 


### PR DESCRIPTION
## What

`Read` and `ImportState` on `eon_restore_account` fetched **all** restore accounts and scanned for a matching ID. This switches them to the new single-account GET endpoint:

`GET /customer/v1/projects/{projectId}/restore_accounts/{accountId}`

A 404 from the endpoint means the account is gone — `Read` drops it from state (recreate on next apply), `ImportState` surfaces a not-found error.

## Dependency chain (why CI is red / draft)

1. **eon-service#36630** adds the endpoint + marks it public (`getRestoreAccount`, `read:restore_accounts`).
2. On merge, `eon-sdk-go` regenerates and releases `AccountsAPI.GetRestoreAccount`.
3. Bump `eon-sdk-go` here → build goes green → un-draft → merge.

Until step 2, `go build` fails only on `AccountsAPI.GetRestoreAccount undefined` — expected. This PR exists now to satisfy eon-service's "Validate Public API Changes" gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)