### PR TITLE
feat(provider): full restore account lifecycle parity (EON-13193)

### DIFF
--- a/docs/resources/restore_account.md
+++ b/docs/resources/restore_account.md
@@ -100,7 +100,7 @@ output "gcp_restore_account" {
 - `created_at` (String) Date and time the restore account was connected to the Eon project.
 - `id` (String) Eon-assigned restore account ID.
 - `provider_account_id` (String, Deprecated) Cloud-provider-assigned account ID (AWS account ID or Azure subscription ID). Computed from the `aws` or `azure` block.
-- `status` (String) Connection status of the AWS account, Azure subscription, or GCP project. Only `CONNECTED` restore accounts can be restored to. Possible values: `CONNECTED`, `DISCONNECTED`, `INSUFFICIENT_PERMISSIONS`.
+- `status` (String) Connection status of the AWS account, Azure subscription, or GCP project. Only `CONNECTED` restore accounts can be restored to. The provider automatically reconnects accounts that drift to `DISCONNECTED`. Possible values: `CONNECTED`, `DISCONNECTED`, `INSUFFICIENT_PERMISSIONS`.
 - `updated_at` (String) Date and time the restore account was last updated.
 
 <a id="nestedblock--aws"></a>

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -600,6 +600,97 @@ func (c *EonClient) DeleteRestoreAccount(ctx context.Context, accountId string) 
 	return nil
 }
 
+// UpdateRestoreAccountRequest contains the fields that can be updated on a restore account.
+type UpdateRestoreAccountRequest struct {
+	Name                     *string
+	RestoreAccountAttributes *UpdateRestoreAccountAttributes
+}
+
+// UpdateRestoreAccountAttributes contains cloud-provider-specific attributes to update.
+// The API supports updating AWS (role_arn) and GCP (service_account); Azure attributes
+// are immutable and require replacement.
+type UpdateRestoreAccountAttributes struct {
+	Aws *UpdateAwsRestoreAccountAttributes
+	Gcp *UpdateGcpRestoreAccountAttributes
+}
+
+// UpdateAwsRestoreAccountAttributes contains AWS-specific attributes to update.
+type UpdateAwsRestoreAccountAttributes struct {
+	RoleArn *string
+}
+
+// UpdateGcpRestoreAccountAttributes contains GCP-specific attributes to update.
+type UpdateGcpRestoreAccountAttributes struct {
+	ServiceAccount *string
+}
+
+// UpdateRestoreAccount updates mutable fields of a restore account via
+// PATCH /v1/projects/{projectId}/restore-accounts/{accountId}.
+func (c *EonClient) UpdateRestoreAccount(ctx context.Context, accountId string, req UpdateRestoreAccountRequest) (*externalEonSdkAPI.RestoreAccount, error) {
+	if err := c.tokenRefresher.EnsureValidToken(); err != nil {
+		return nil, fmt.Errorf("failed to ensure valid token: %w", err)
+	}
+
+	sdkReq := externalEonSdkAPI.NewUpdateRestoreAccountRequest()
+	if req.Name != nil {
+		sdkReq.SetName(*req.Name)
+	}
+	if req.RestoreAccountAttributes != nil {
+		attrs := externalEonSdkAPI.NewUpdateRestoreAccountAttributesInput()
+		if req.RestoreAccountAttributes.Aws != nil {
+			awsAttrs := externalEonSdkAPI.UpdateAwsRestoreAccountAttributes{}
+			if req.RestoreAccountAttributes.Aws.RoleArn != nil {
+				awsAttrs.SetRoleArn(*req.RestoreAccountAttributes.Aws.RoleArn)
+			}
+			attrs.SetAws(awsAttrs)
+		}
+		if req.RestoreAccountAttributes.Gcp != nil {
+			gcpAttrs := externalEonSdkAPI.UpdateGcpRestoreAccountAttributes{}
+			if req.RestoreAccountAttributes.Gcp.ServiceAccount != nil {
+				gcpAttrs.SetServiceAccount(*req.RestoreAccountAttributes.Gcp.ServiceAccount)
+			}
+			attrs.SetGcp(gcpAttrs)
+		}
+		sdkReq.SetRestoreAccountAttributes(*attrs)
+	}
+
+	resp, httpResp, err := c.client.AccountsAPI.UpdateRestoreAccount(ctx, c.projectID, accountId).
+		UpdateRestoreAccountRequest(*sdkReq).Execute()
+	if apiErr := c.handleAPIError(err, httpResp, "failed to update restore account"); apiErr != nil {
+		return nil, apiErr
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	if httpResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(httpResp.Body)
+		return nil, fmt.Errorf("API error %d: %s", httpResp.StatusCode, string(body))
+	}
+
+	account := resp.GetRestoreAccount()
+	return &account, nil
+}
+
+// ReconnectRestoreAccount reconnects a previously disconnected restore account.
+func (c *EonClient) ReconnectRestoreAccount(ctx context.Context, accountId string) (*externalEonSdkAPI.RestoreAccount, error) {
+	if err := c.tokenRefresher.EnsureValidToken(); err != nil {
+		return nil, fmt.Errorf("failed to ensure valid token: %w", err)
+	}
+
+	resp, httpResp, err := c.client.AccountsAPI.ReconnectRestoreAccount(ctx, c.projectID, accountId).Execute()
+	if apiErr := c.handleAPIError(err, httpResp, "failed to reconnect restore account"); apiErr != nil {
+		return nil, apiErr
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	if httpResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(httpResp.Body)
+		return nil, fmt.Errorf("API error %d: %s", httpResp.StatusCode, string(body))
+	}
+
+	account := resp.GetRestoreAccount()
+	return &account, nil
+}
+
 // GetRestoreAccountConnectivityConfig retrieves the connectivity configuration of a restore account.
 func (c *EonClient) GetRestoreAccountConnectivityConfig(ctx context.Context, accountId string) (*externalEonSdkAPI.RestoreAccountConnectivityConfig, error) {
 	if err := c.tokenRefresher.EnsureValidToken(); err != nil {

--- a/internal/provider/resource_restore_account.go
+++ b/internal/provider/resource_restore_account.go
@@ -78,9 +78,9 @@ func (r *RestoreAccountResource) Schema(ctx context.Context, req resource.Schema
 				DeprecationMessage:  "Use 'aws { role_arn = \"...\" }' instead.",
 			},
 			"status": schema.StringAttribute{
-				MarkdownDescription: "Connection status of the AWS account, Azure subscription, or GCP project. Only `CONNECTED` restore accounts can be restored to. Possible values: `CONNECTED`, `DISCONNECTED`, `INSUFFICIENT_PERMISSIONS`.",
+				MarkdownDescription: "Connection status of the AWS account, Azure subscription, or GCP project. Only `CONNECTED` restore accounts can be restored to. The provider automatically reconnects accounts that drift to `DISCONNECTED`. Possible values: `CONNECTED`, `DISCONNECTED`, `INSUFFICIENT_PERMISSIONS`.",
 				Computed:            true,
-				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+				PlanModifiers:       []planmodifier.String{ReconnectOnDisconnected()},
 			},
 			"created_at": schema.StringAttribute{
 				MarkdownDescription: "Date and time the restore account was connected to the Eon project.",
@@ -343,21 +343,220 @@ func (r *RestoreAccountResource) Read(ctx context.Context, req resource.ReadRequ
 		data.UpdatedAt = types.StringValue(time.Now().Format(time.RFC3339))
 	}
 
+	// Surface account statuses the provider cannot auto-remediate so the user
+	// sees them in plan output. DISCONNECTED is handled by the plan modifier
+	// and the Update flow; anything else non-CONNECTED needs manual attention.
+	status := data.Status.ValueString()
+	if status != "" && status != "CONNECTED" && status != "DISCONNECTED" {
+		resp.Diagnostics.AddAttributeWarning(
+			path.Root("status"),
+			"Restore Account Requires Manual Intervention",
+			fmt.Sprintf(
+				"Restore account %s is in status %q. The provider cannot automatically remediate this state; resolve the underlying issue in the Eon console or cloud provider and re-run.",
+				data.Id.ValueString(), status,
+			),
+		)
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *RestoreAccountResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data RestoreAccountResourceModel
+	var plan RestoreAccountResourceModel
+	var state RestoreAccountResourceModel
 
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// For now, most changes require replace due to API limitations
-	resp.Diagnostics.AddWarning("Update Not Supported", "Most restore account changes require replacement. Please update your configuration to force replacement if needed.")
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	// Azure restore accounts are immutable via the update API; any change to the
+	// azure block must go through replacement. Reject it here with a clear error
+	// rather than silently no-op'ing (the cloud_provider itself already forces
+	// replacement, so this only fires for edits within the azure block).
+	if azureAttributesChanged(plan.Azure, state.Azure) {
+		resp.Diagnostics.AddError(
+			"Azure Restore Account Update Not Supported",
+			"Azure restore account attributes (tenant_id, subscription_id, resource_group_name) cannot be updated in place. "+
+				"Recreate the resource (e.g. `terraform taint`) to apply these changes.",
+		)
+		return
+	}
+
+	accountId := state.Id.ValueString()
+	var latestAccount *externalEonSdkAPI.RestoreAccount
+
+	// Step 1: Update mutable fields (name, aws.role_arn, gcp.service_account) if changed.
+	updateReq := r.buildUpdateRequest(plan, state)
+	if updateReq != nil {
+		tflog.Info(ctx, "Updating restore account", map[string]interface{}{
+			"id": accountId,
+		})
+
+		account, err := r.client.UpdateRestoreAccount(ctx, accountId, *updateReq)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Update Failed",
+				fmt.Sprintf("Unable to update restore account %s: %s", accountId, err),
+			)
+			return
+		}
+		latestAccount = account
+	}
+
+	// Step 2: Reconnect if the account is DISCONNECTED.
+	if state.Status.ValueString() == "DISCONNECTED" {
+		tflog.Info(ctx, "Restore account is disconnected, attempting reconnect", map[string]interface{}{
+			"id": accountId,
+		})
+
+		account, err := r.client.ReconnectRestoreAccount(ctx, accountId)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Reconnect Failed",
+				fmt.Sprintf("Unable to reconnect restore account %s: %s", accountId, err),
+			)
+			return
+		}
+		latestAccount = account
+
+		tflog.Info(ctx, "Restore account reconnected", map[string]interface{}{
+			"id": accountId,
+		})
+	}
+
+	// Step 3: Build new state from the API response, or read back if no response was returned.
+	if latestAccount == nil {
+		fetched, err := r.readRestoreAccount(ctx, accountId, plan)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Read After Update Failed",
+				fmt.Sprintf("Unable to read restore account %s after update: %s", accountId, err),
+			)
+			return
+		}
+		resp.Diagnostics.Append(resp.State.Set(ctx, fetched)...)
+		return
+	}
+
+	newState := r.mapAccountToState(latestAccount, plan)
+	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
+}
+
+// azureAttributesChanged reports whether any azure block attribute differs
+// between plan and state. Restore accounts cannot update azure attributes in
+// place, so such a change must force replacement.
+func azureAttributesChanged(plan, state *AzureAccountConfigModel) bool {
+	if plan == nil || state == nil {
+		return false
+	}
+	return plan.TenantId.ValueString() != state.TenantId.ValueString() ||
+		plan.SubscriptionId.ValueString() != state.SubscriptionId.ValueString() ||
+		plan.ResourceGroupName.ValueString() != state.ResourceGroupName.ValueString()
+}
+
+// buildUpdateRequest compares plan and state and returns an UpdateRestoreAccountRequest
+// if any mutable fields changed. Returns nil if nothing needs updating.
+func (r *RestoreAccountResource) buildUpdateRequest(plan, state RestoreAccountResourceModel) *client.UpdateRestoreAccountRequest {
+	var req client.UpdateRestoreAccountRequest
+	var changed bool
+
+	if plan.Name.ValueString() != state.Name.ValueString() {
+		name := plan.Name.ValueString()
+		req.Name = &name
+		changed = true
+	}
+
+	if plan.Aws != nil && state.Aws != nil &&
+		plan.Aws.RoleArn.ValueString() != state.Aws.RoleArn.ValueString() {
+		roleArn := plan.Aws.RoleArn.ValueString()
+		req.RestoreAccountAttributes = &client.UpdateRestoreAccountAttributes{
+			Aws: &client.UpdateAwsRestoreAccountAttributes{
+				RoleArn: &roleArn,
+			},
+		}
+		changed = true
+	}
+
+	if plan.Gcp != nil && state.Gcp != nil &&
+		plan.Gcp.ServiceAccount.ValueString() != state.Gcp.ServiceAccount.ValueString() {
+		serviceAccount := plan.Gcp.ServiceAccount.ValueString()
+		req.RestoreAccountAttributes = &client.UpdateRestoreAccountAttributes{
+			Gcp: &client.UpdateGcpRestoreAccountAttributes{
+				ServiceAccount: &serviceAccount,
+			},
+		}
+		changed = true
+	}
+
+	if !changed {
+		return nil
+	}
+	return &req
+}
+
+// mapAccountToState maps a RestoreAccount API response to the Terraform resource model.
+// The plan is used to preserve fields not returned by the API (timestamps).
+func (r *RestoreAccountResource) mapAccountToState(account *externalEonSdkAPI.RestoreAccount, plan RestoreAccountResourceModel) *RestoreAccountResourceModel {
+	data := RestoreAccountResourceModel{
+		Id:                types.StringValue(account.Id),
+		Name:              types.StringValue(account.GetName()),
+		Status:            types.StringValue(string(account.Status)),
+		ProviderAccountId: types.StringValue(account.GetProviderAccountId()),
+		CreatedAt:         plan.CreatedAt,
+		UpdatedAt:         types.StringValue(time.Now().Format(time.RFC3339)),
+	}
+
+	cloudProvider := CloudProvider(account.RestoreAccountAttributes.GetCloudProvider())
+	data.CloudProvider = types.StringValue(cloudProvider.String())
+
+	switch cloudProvider {
+	case CloudProviderAWS:
+		if account.RestoreAccountAttributes.HasAws() {
+			awsAttrs := account.RestoreAccountAttributes.GetAws()
+			data.Aws = &AwsAccountConfigModel{
+				RoleArn: types.StringValue(awsAttrs.GetRoleArn()),
+			}
+			data.Role = types.StringValue(awsAttrs.GetRoleArn())
+		}
+	case CloudProviderAzure:
+		if account.RestoreAccountAttributes.HasAzure() {
+			azureAttrs := account.RestoreAccountAttributes.GetAzure()
+			data.Azure = &AzureAccountConfigModel{
+				TenantId:       types.StringValue(azureAttrs.GetTenantId()),
+				SubscriptionId: types.StringValue(account.GetProviderAccountId()),
+			}
+			if azureAttrs.HasResourceGroupName() {
+				data.Azure.ResourceGroupName = types.StringValue(azureAttrs.GetResourceGroupName())
+			}
+		}
+		data.Role = types.StringNull()
+	case CloudProviderGCP:
+		if account.RestoreAccountAttributes.HasGcp() {
+			gcpAttrs := account.RestoreAccountAttributes.GetGcp()
+			data.Gcp = &GcpAccountConfigModel{
+				ProjectId:      types.StringValue(account.GetProviderAccountId()),
+				ServiceAccount: types.StringValue(gcpAttrs.GetServiceAccount()),
+			}
+		}
+		data.Role = types.StringNull()
+	}
+
+	return &data
+}
+
+// readRestoreAccount fetches a restore account by ID and maps it to the resource model.
+func (r *RestoreAccountResource) readRestoreAccount(ctx context.Context, accountId string, plan RestoreAccountResourceModel) (*RestoreAccountResourceModel, error) {
+	account, err := r.client.GetRestoreAccount(ctx, accountId)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get restore account: %w", err)
+	}
+	return r.mapAccountToState(account, plan), nil
 }
 
 func (r *RestoreAccountResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/resource_restore_account_unit_test.go
+++ b/internal/provider/resource_restore_account_unit_test.go
@@ -1,0 +1,98 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func awsModel(roleArn string) *AwsAccountConfigModel {
+	return &AwsAccountConfigModel{RoleArn: types.StringValue(roleArn)}
+}
+
+func gcpModel(projectID, serviceAccount string) *GcpAccountConfigModel {
+	return &GcpAccountConfigModel{
+		ProjectId:      types.StringValue(projectID),
+		ServiceAccount: types.StringValue(serviceAccount),
+	}
+}
+
+func azureModel(tenant, sub, rg string) *AzureAccountConfigModel {
+	return &AzureAccountConfigModel{
+		TenantId:          types.StringValue(tenant),
+		SubscriptionId:    types.StringValue(sub),
+		ResourceGroupName: types.StringValue(rg),
+	}
+}
+
+func TestRestoreAccount_azureAttributesChanged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		plan, state *AzureAccountConfigModel
+		want        bool
+	}{
+		{"both nil", nil, nil, false},
+		{"plan nil", nil, azureModel("t", "s", "rg"), false},
+		{"state nil", azureModel("t", "s", "rg"), nil, false},
+		{"identical", azureModel("t", "s", "rg"), azureModel("t", "s", "rg"), false},
+		{"tenant changed", azureModel("t2", "s", "rg"), azureModel("t", "s", "rg"), true},
+		{"subscription changed", azureModel("t", "s2", "rg"), azureModel("t", "s", "rg"), true},
+		{"resource group changed", azureModel("t", "s", "rg2"), azureModel("t", "s", "rg"), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, azureAttributesChanged(tt.plan, tt.state))
+		})
+	}
+}
+
+func TestRestoreAccount_buildUpdateRequest(t *testing.T) {
+	t.Parallel()
+	r := &RestoreAccountResource{}
+
+	t.Run("no changes returns nil", func(t *testing.T) {
+		t.Parallel()
+		plan := RestoreAccountResourceModel{Name: types.StringValue("acct"), Aws: awsModel("arn:x")}
+		state := RestoreAccountResourceModel{Name: types.StringValue("acct"), Aws: awsModel("arn:x")}
+		assert.Nil(t, r.buildUpdateRequest(plan, state))
+	})
+
+	t.Run("name change", func(t *testing.T) {
+		t.Parallel()
+		plan := RestoreAccountResourceModel{Name: types.StringValue("new")}
+		state := RestoreAccountResourceModel{Name: types.StringValue("old")}
+		req := r.buildUpdateRequest(plan, state)
+		require.NotNil(t, req)
+		require.NotNil(t, req.Name)
+		assert.Equal(t, "new", *req.Name)
+		assert.Nil(t, req.RestoreAccountAttributes)
+	})
+
+	t.Run("aws role_arn change", func(t *testing.T) {
+		t.Parallel()
+		plan := RestoreAccountResourceModel{Name: types.StringValue("acct"), Aws: awsModel("arn:new")}
+		state := RestoreAccountResourceModel{Name: types.StringValue("acct"), Aws: awsModel("arn:old")}
+		req := r.buildUpdateRequest(plan, state)
+		require.NotNil(t, req)
+		require.NotNil(t, req.RestoreAccountAttributes)
+		require.NotNil(t, req.RestoreAccountAttributes.Aws)
+		assert.Equal(t, "arn:new", *req.RestoreAccountAttributes.Aws.RoleArn)
+	})
+
+	t.Run("gcp service_account change", func(t *testing.T) {
+		t.Parallel()
+		plan := RestoreAccountResourceModel{Name: types.StringValue("acct"), Gcp: gcpModel("p", "sa-new@x")}
+		state := RestoreAccountResourceModel{Name: types.StringValue("acct"), Gcp: gcpModel("p", "sa-old@x")}
+		req := r.buildUpdateRequest(plan, state)
+		require.NotNil(t, req)
+		require.NotNil(t, req.RestoreAccountAttributes)
+		require.NotNil(t, req.RestoreAccountAttributes.Gcp)
+		assert.Equal(t, "sa-new@x", *req.RestoreAccountAttributes.Gcp.ServiceAccount)
+	})
+}


### PR DESCRIPTION
## What

Completes EON-13193. #98 delivered restore-account read parity (single-GET, 404→drift) + the eon-sdk-go v1.160.0 bump. This adds the rest of the lifecycle, mirroring `eon_source_account`:

- **client:** `UpdateRestoreAccount` + `ReconnectRestoreAccount` (+ request structs). Restore supports updating `name`, `aws.role_arn`, and `gcp.service_account`. Azure attributes are immutable via the SDK (`UpdateRestoreAccountAttributesInput` exposes only `SetAws`/`SetGcp`).
- **resource `Update`:** was a stub that returned success while silently never reaching Eon (state lied). Now: update mutable fields → reconnect when the account is `DISCONNECTED` → read back.
- **self-heal:** `status` uses the `ReconnectOnDisconnected()` plan modifier, so a drifted account triggers an Update (reconnect) on next apply.
- **Read:** emits a manual-intervention warning for non-`CONNECTED`/non-`DISCONNECTED` states, matching source.
- **Azure edits:** return a clear "recreate to apply" error — the `cloud_provider` schema blocks are shared with the source resource, so they can't be marked `RequiresReplace` without changing source behavior.

## Tests / docs

- Unit tests for the pure decision fns (`azureAttributesChanged`, `buildUpdateRequest`).
- `docs/resources/restore_account.md` status line updated. Full `tfplugindocs` regen should run from a normally-named checkout at release time (it infers the provider name from the dir).

## Notes

No version bump / tag here — release (v2.0.19) is a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)