### PR TITLE
fix(client): pass projectId and accountId in correct order to connectivity-config SDK calls (EON-14842)

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -697,7 +697,7 @@ func (c *EonClient) GetRestoreAccountConnectivityConfig(ctx context.Context, acc
 		return nil, fmt.Errorf("failed to ensure valid token: %w", err)
 	}
 
-	resp, httpResp, err := c.client.AccountsAPI.GetRestoreAccountConnectivityConfig(ctx, accountId, c.projectID).Execute()
+	resp, httpResp, err := c.client.AccountsAPI.GetRestoreAccountConnectivityConfig(ctx, c.projectID, accountId).Execute()
 	if apiErr := c.handleAPIError(err, httpResp, "failed to get restore account connectivity config"); apiErr != nil {
 		return nil, apiErr
 	}
@@ -718,7 +718,7 @@ func (c *EonClient) UpdateRestoreAccountConnectivityConfig(ctx context.Context, 
 		return nil, fmt.Errorf("failed to ensure valid token: %w", err)
 	}
 
-	resp, httpResp, err := c.client.AccountsAPI.UpdateRestoreAccountConnectivityConfig(ctx, accountId, c.projectID).UpdateRestoreAccountConnectivityConfigRequest(req).Execute()
+	resp, httpResp, err := c.client.AccountsAPI.UpdateRestoreAccountConnectivityConfig(ctx, c.projectID, accountId).UpdateRestoreAccountConnectivityConfigRequest(req).Execute()
 	if apiErr := c.handleAPIError(err, httpResp, "failed to update restore account connectivity config"); apiErr != nil {
 		return nil, apiErr
 	}
@@ -740,7 +740,7 @@ func (c *EonClient) DeleteRestoreAccountConnectivityConfig(ctx context.Context, 
 		return fmt.Errorf("failed to ensure valid token: %w", err)
 	}
 
-	httpResp, err := c.client.AccountsAPI.DeleteRestoreAccountConnectivityConfig(ctx, accountId, c.projectID).Execute()
+	httpResp, err := c.client.AccountsAPI.DeleteRestoreAccountConnectivityConfig(ctx, c.projectID, accountId).Execute()
 	if apiErr := c.handleAPIError(err, httpResp, "failed to delete restore account connectivity config"); apiErr != nil {
 		return apiErr
 	}

--- a/internal/client/restore_account_connectivity_config_test.go
+++ b/internal/client/restore_account_connectivity_config_test.go
@@ -1,0 +1,80 @@
+package client
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	externalEonSdkAPI "github.com/eon-io/eon-sdk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The SDK takes (projectId, accountId) in that order; passing them swapped produces a valid-looking
+// URL that the API rejects with 403 (EON-14842), so these tests pin the exact request path.
+const connectivityConfigPath = "/api/v1/projects/project-1/restore-accounts/account-1/connectivity-config"
+
+const connectivityConfigResponse = `{
+	"restoreAccountConfig": {
+		"restoreAccountId": "account-1",
+		"config": {}
+	}
+}`
+
+func TestGetRestoreAccountConnectivityConfig(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, connectivityConfigPath, r.URL.Path)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(connectivityConfigResponse)),
+		}, nil
+	}))
+
+	config, err := c.GetRestoreAccountConnectivityConfig(context.Background(), "account-1")
+	require.NoError(t, err)
+	assert.Equal(t, "account-1", config.GetRestoreAccountId())
+}
+
+func TestUpdateRestoreAccountConnectivityConfig(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, connectivityConfigPath, r.URL.Path)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(connectivityConfigResponse)),
+		}, nil
+	}))
+
+	config, err := c.UpdateRestoreAccountConnectivityConfig(context.Background(), "account-1",
+		externalEonSdkAPI.UpdateRestoreAccountConnectivityConfigRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, "account-1", config.GetRestoreAccountId())
+}
+
+func TestDeleteRestoreAccountConnectivityConfig(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, connectivityConfigPath, r.URL.Path)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{}`)),
+		}, nil
+	}))
+
+	require.NoError(t, c.DeleteRestoreAccountConnectivityConfig(context.Background(), "account-1"))
+}


### PR DESCRIPTION
## Problem

Every operation of the `eon_restore_account_connectivity_config` resource fails with 403 `Project not in role permissions` (reported by McKinsey via TFE, [EON-14842](https://linear.app/eon-io/issue/EON-14842)).

The SDK signature is `(ctx, projectId, accountId)`, but the three client wrappers passed `(ctx, accountId, c.projectID)`, so requests went to:

```
PUT /v1/projects/{restoreAccountId}/restore-accounts/{projectId}/connectivity-config
```

The api-gateway rejects the swapped project ID before the handler runs (`Built-in role failed project ownership validation`). Confirmed in prod logs — traceIds `c14121debd8b943490f5369600a675b5`, `1f2c411c3ac2accdf9fea3f57a6211a1`.

## Fix

Swap the arguments to `(ctx, c.projectID, accountId)` in `GetRestoreAccountConnectivityConfig`, `UpdateRestoreAccountConnectivityConfig`, and `DeleteRestoreAccountConnectivityConfig` — matching every other wrapper in `client.go`.

## Tests

Added unit tests pinning the exact request path for all three operations (same round-tripper harness as `cloud_resource_configuration_test.go`). They fail against the old code and pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://eon.devinenterprise.com/review/eon-io/terraform-provider-eon/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->