### PR TITLE
chore(deps): bump eon-sdk-go to v1.173.0 (capability sync) (EON-16837)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/eon-io/terraform-provider-eon
 go 1.25.8
 
 require (
-	github.com/eon-io/eon-sdk-go v1.170.0
+	github.com/eon-io/eon-sdk-go v1.173.0
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/eon-io/eon-sdk-go v1.170.0 h1:/MBBk9WfmqmkrZsJQd+ZSieuFtJ9kS97qfPuHTpDBss=
-github.com/eon-io/eon-sdk-go v1.170.0/go.mod h1:NWrS3rllESPQ7vzryT7+bHkOpNrXbXcnRtaPlv0LScw=
+github.com/eon-io/eon-sdk-go v1.173.0 h1:M5oLdWKUHDKASdin/gApaLSObwQFLMY7k7lBILwpahQ=
+github.com/eon-io/eon-sdk-go v1.173.0/go.mod h1:NWrS3rllESPQ7vzryT7+bHkOpNrXbXcnRtaPlv0LScw=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=


### PR DESCRIPTION
## What

SDK dependency bump `v1.170.0` → `v1.173.0`. Based directly on `main` — this is the exact PR shape the capability-sync pipeline in the private eon-service repo opens automatically on future SDK releases (eon-io/eon-service#40123).

Capability analysis, triage decisions, and gap reports live in eon-service under `tools/terraform-capsync/capabilities/` — this public repo carries no pipeline machinery.

## Gap summary at v1.173.0

104 operations: 58 covered, 1 covered internally, **27 gaps across 12 capabilities**, 18 skipped, 2 flagged for reviewer decision (`listResources`/`getResource`).

Capability PRs chain off this branch, one capability per PR — first one: #109, `eon_backup_posture_control` (v1.173.0 introduced the backup-posture-controls API, which is why it needs this bump).

Build and full test suite pass.