### PR TITLE
fix(ci): take the Linear ticket ID from PR title and branch only (EON-16912)

### DIFF
--- a/.github/actions/update-linear-on-merge/action.yml
+++ b/.github/actions/update-linear-on-merge/action.yml
@@ -10,10 +10,6 @@ inputs:
   pr_branch:
     description: "Pull request head branch name"
     required: true
-  pr_body:
-    description: "Pull request body"
-    required: false
-    default: ""
 runs:
   using: "composite"
   steps:
@@ -25,9 +21,11 @@ runs:
       shell: bash
       env:
         LINEAR_API_KEY: ${{ inputs.linear_api_key }}
+        # A PR title is author-controlled text. Interpolating it into the script body would let
+        # backticks in a title run as shell commands; an env var is expanded after bash parses.
+        PR_TITLE: ${{ inputs.pr_title }}
+        PR_BRANCH: ${{ inputs.pr_branch }}
       run: |
         python3 "${{ github.action_path }}/update_linear_on_merge.py" \
-          --pr-title "${{ inputs.pr_title }}" \
-          --pr-branch "${{ inputs.pr_branch }}" \
-          --pr-body "${{ inputs.pr_body }}" \
-          --linear-api-key "${{ inputs.linear_api_key }}"
+          --pr-title "$PR_TITLE" \
+          --pr-branch "$PR_BRANCH"

--- a/.github/actions/update-linear-on-merge/test_update_linear_on_merge.py
+++ b/.github/actions/update-linear-on-merge/test_update_linear_on_merge.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Self-check for ticket-ID extraction: python3 test_update_linear_on_merge.py"""
+
+from update_linear_on_merge import extract_ticket_id
+
+
+def main():
+    assert extract_ticket_id("feat(provider): add a thing (EON-15403)", "some-branch") == "EON-15403"
+    assert extract_ticket_id("no ticket here", "assafrabinowitz-eon-15403-add-a-thing") == "EON-15403"
+    # Title wins over branch, so a PR retargeted to another ticket moves the one it names.
+    assert extract_ticket_id("fix: thing (EON-1)", "user-eon-2-thing") == "EON-1"
+    assert extract_ticket_id("chore: no ticket", "throwaway-branch") is None
+
+    # The PR body is deliberately not a source: title and branch both carry the ID by convention,
+    # and reading the body was what let a backtick in a description run as a shell command.
+    try:
+        extract_ticket_id("chore: no ticket", "throwaway-branch", "mentions EON-15403")
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("extract_ticket_id must not accept a PR body")
+
+    print("ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/update-linear-on-merge/update_linear_on_merge.py
+++ b/.github/actions/update-linear-on-merge/update_linear_on_merge.py
@@ -3,10 +3,11 @@
 update_linear_on_merge.py
 Update Linear ticket to Deployed state when a PR is merged.
 
-Extracts the EON-XXXX ticket ID from the PR title, branch name, or body,
-looks it up in Linear, and moves it to the Deployed state.
+Extracts the EON-XXXX ticket ID from the PR title or branch name, looks it up
+in Linear, and moves it to the Deployed state.
 """
 
+import os
 import re
 import sys
 from typing import Optional
@@ -19,9 +20,9 @@ DEPLOYED_STATE_ID = "0e6659ab-646c-43e4-81b1-d858126bc390"
 LINEAR_TICKET_PATTERN = re.compile(r"EON-(\d+)", re.IGNORECASE)
 
 
-def extract_ticket_id(pr_title: str, pr_branch: str, pr_body: str) -> Optional[str]:
-    """Extract EON-XXXX ticket ID from PR title, branch, or body."""
-    for source in [pr_title, pr_branch, pr_body]:
+def extract_ticket_id(pr_title: str, pr_branch: str) -> Optional[str]:
+    """Extract EON-XXXX ticket ID from PR title or branch."""
+    for source in [pr_title, pr_branch]:
         match = LINEAR_TICKET_PATTERN.search(source)
         if match:
             return match.group(0).upper()
@@ -112,20 +113,25 @@ def main():
     parser = argparse.ArgumentParser(description="Update Linear ticket to Deployed on PR merge")
     parser.add_argument("--pr-title", required=True, help="Pull request title")
     parser.add_argument("--pr-branch", required=True, help="Pull request head branch name")
-    parser.add_argument("--pr-body", default="", help="Pull request body")
-    parser.add_argument("--linear-api-key", required=True, help="Linear API key")
     args = parser.parse_args()
 
+    # The key comes from the environment, not argv: anything else on the runner can read another
+    # process's command line out of /proc.
+    linear_api_key = os.environ.get("LINEAR_API_KEY", "")
+    if not linear_api_key:
+        print("LINEAR_API_KEY is not set.", file=sys.stderr)
+        sys.exit(1)
+
     # Extract ticket ID
-    ticket_id = extract_ticket_id(args.pr_title, args.pr_branch, args.pr_body)
+    ticket_id = extract_ticket_id(args.pr_title, args.pr_branch)
     if not ticket_id:
-        print("No Linear ticket ID found in PR title, branch, or body. Skipping.")
+        print("No Linear ticket ID found in PR title or branch. Skipping.")
         return
 
     print(f"Found Linear ticket: {ticket_id}")
 
     # Look up the issue
-    issue = lookup_linear_issue(args.linear_api_key, ticket_id)
+    issue = lookup_linear_issue(linear_api_key, ticket_id)
     if not issue:
         return
 
@@ -137,7 +143,7 @@ def main():
 
     # Update to Deployed
     print(f"Updating {ticket_id} from {state_name} to Deployed...")
-    update_linear_issue(args.linear_api_key, issue["id"], ticket_id)
+    update_linear_issue(linear_api_key, issue["id"], ticket_id)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/linear-update-on-merge.yml
+++ b/.github/workflows/linear-update-on-merge.yml
@@ -24,4 +24,3 @@ jobs:
           linear_api_key: ${{ secrets.LINEAR_API_KEY }}
           pr_title: ${{ github.event.pull_request.title }}
           pr_branch: ${{ github.event.pull_request.head.ref }}
-          pr_body: ${{ github.event.pull_request.body }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ crash.log
 *.swo
 *~
 
+# Python bytecode from the CI action scripts
+__pycache__/
+*.pyc
+
 # OS files
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
The `Update Linear on Merge` job failed on PR #110 ([run](https://github.com/eon-io/terraform-provider-eon/actions/runs/30798588787)) with ~40 `command not found` lines and exit code 2, so the ticket never moved to Deployed. Same code path also lets PR text run as shell commands on the runner.

## Cause

`action.yml` interpolated the PR body into a bash `run:` block:

```yaml
--pr-body "${{ inputs.pr_body }}"
```

`${{ }}` pastes text into the script *before* bash parses it, so the surrounding double quotes do nothing: every backtick span in a PR description executes as a command substitution. Any PR body with inline code breaks the job, and a crafted body runs arbitrary commands on the runner, which has `LINEAR_API_KEY` in scope. The title was interpolated identically.

## Why dropping the body is safe

It was only the third fallback for scraping `EON-\d+`:

```python
for source in [pr_title, pr_branch, pr_body]:
```

Both earlier sources always carry the ID — `pull-request-rules.md` requires `(EON-XXXX)` in the title, and branches come from Linear's `gitBranchName`, which embeds it. On #110 the title matched first and the body was never read for anything.

## Changes

- `pr_body` input, `--pr-body` argument, and the third lookup source are gone; the ID now comes from title, then branch.
- Title and branch pass through `env:` as `"$PR_TITLE"` / `"$PR_BRANCH"` — bash expands those after parsing, so author-controlled text is never re-parsed as script.
- `LINEAR_API_KEY` is read from the environment instead of `--linear-api-key`, which put the secret in argv where any other process on the runner could read it from `/proc`. The action already exported it; the script just ignored it.
- `test_update_linear_on_merge.py` — plain `python3` self-check covering ID-from-title, ID-from-branch, title-wins-over-branch, no-ticket, and a signature assert that fails if a body parameter returns.
- `__pycache__/` and `*.pyc` added to `.gitignore`, since running the check creates them.

## Verification

`python3 test_update_linear_on_merge.py` passes, both YAML files parse, and running the script with an empty `LINEAR_API_KEY` exits 1 with `LINEAR_API_KEY is not set.` This PR's own merge exercises the fixed action, since `actions/checkout` on `pull_request` gets the merge ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
