### PR TITLE
fix(ci): authenticate the Linear merge action with OAuth (EON-16919)

### DIFF
--- a/.github/actions/update-linear-on-merge/action.yml
+++ b/.github/actions/update-linear-on-merge/action.yml
@@ -1,8 +1,11 @@
 name: "Update Linear on Merge"
 description: "Update Linear ticket to Deployed state when a PR is merged"
 inputs:
-  linear_api_key:
-    description: "Linear API key"
+  oauth_client_id:
+    description: "Linear OAuth client ID for client_credentials flow"
+    required: true
+  oauth_client_secret:
+    description: "Linear OAuth client secret for client_credentials flow"
     required: true
   pr_title:
     description: "Pull request title"
@@ -20,7 +23,8 @@ runs:
     - name: Update Linear ticket
       shell: bash
       env:
-        LINEAR_API_KEY: ${{ inputs.linear_api_key }}
+        OAUTH_CLIENT_ID: ${{ inputs.oauth_client_id }}
+        OAUTH_CLIENT_SECRET: ${{ inputs.oauth_client_secret }}
         # A PR title is author-controlled text. Interpolating it into the script body would let
         # backticks in a title run as shell commands; an env var is expanded after bash parses.
         PR_TITLE: ${{ inputs.pr_title }}

--- a/.github/actions/update-linear-on-merge/update_linear_on_merge.py
+++ b/.github/actions/update-linear-on-merge/update_linear_on_merge.py
@@ -16,6 +16,7 @@ import requests
 
 # Linear API configuration
 LINEAR_API_BASE = "https://api.linear.app/graphql"
+LINEAR_OAUTH_TOKEN_URL = "https://api.linear.app/oauth/token"
 DEPLOYED_STATE_ID = "0e6659ab-646c-43e4-81b1-d858126bc390"
 LINEAR_TICKET_PATTERN = re.compile(r"EON-(\d+)", re.IGNORECASE)
 
@@ -29,7 +30,30 @@ def extract_ticket_id(pr_title: str, pr_branch: str) -> Optional[str]:
     return None
 
 
-def lookup_linear_issue(linear_api_key: str, ticket_id: str) -> Optional[dict]:
+def get_oauth_access_token(client_id: str, client_secret: str) -> str:
+    """Exchange OAuth client credentials for a Linear access token."""
+    response = requests.post(
+        LINEAR_OAUTH_TOKEN_URL,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data={
+            "grant_type": "client_credentials",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "scope": "read,write",
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+
+    access_token = response.json().get("access_token")
+    if not access_token:
+        print("No access_token in the Linear OAuth response.", file=sys.stderr)
+        sys.exit(1)
+
+    return access_token
+
+
+def lookup_linear_issue(access_token: str, ticket_id: str) -> Optional[dict]:
     """Look up a Linear issue by identifier."""
     query = f'{{ issue(id: "{ticket_id}") {{ id identifier title state {{ name }} }} }}'
 
@@ -37,7 +61,7 @@ def lookup_linear_issue(linear_api_key: str, ticket_id: str) -> Optional[dict]:
         LINEAR_API_BASE,
         headers={
             "Content-Type": "application/json",
-            "Authorization": linear_api_key,
+            "Authorization": f"Bearer {access_token}",
         },
         json={"query": query},
         timeout=30,
@@ -60,7 +84,7 @@ def lookup_linear_issue(linear_api_key: str, ticket_id: str) -> Optional[dict]:
     return issue
 
 
-def update_linear_issue(linear_api_key: str, issue_id: str, ticket_id: str) -> bool:
+def update_linear_issue(access_token: str, issue_id: str, ticket_id: str) -> bool:
     """Update a Linear issue to Deployed state."""
     mutation = f"""
     mutation {{
@@ -82,7 +106,7 @@ def update_linear_issue(linear_api_key: str, issue_id: str, ticket_id: str) -> b
         LINEAR_API_BASE,
         headers={
             "Content-Type": "application/json",
-            "Authorization": linear_api_key,
+            "Authorization": f"Bearer {access_token}",
         },
         json={"query": mutation},
         timeout=30,
@@ -115,11 +139,12 @@ def main():
     parser.add_argument("--pr-branch", required=True, help="Pull request head branch name")
     args = parser.parse_args()
 
-    # The key comes from the environment, not argv: anything else on the runner can read another
-    # process's command line out of /proc.
-    linear_api_key = os.environ.get("LINEAR_API_KEY", "")
-    if not linear_api_key:
-        print("LINEAR_API_KEY is not set.", file=sys.stderr)
+    # Credentials come from the environment, not argv: anything else on the runner can read
+    # another process's command line out of /proc.
+    client_id = os.environ.get("OAUTH_CLIENT_ID", "")
+    client_secret = os.environ.get("OAUTH_CLIENT_SECRET", "")
+    if not client_id or not client_secret:
+        print("OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET are required.", file=sys.stderr)
         sys.exit(1)
 
     # Extract ticket ID
@@ -130,8 +155,10 @@ def main():
 
     print(f"Found Linear ticket: {ticket_id}")
 
+    access_token = get_oauth_access_token(client_id, client_secret)
+
     # Look up the issue
-    issue = lookup_linear_issue(linear_api_key, ticket_id)
+    issue = lookup_linear_issue(access_token, ticket_id)
     if not issue:
         return
 
@@ -143,7 +170,7 @@ def main():
 
     # Update to Deployed
     print(f"Updating {ticket_id} from {state_name} to Deployed...")
-    update_linear_issue(linear_api_key, issue["id"], ticket_id)
+    update_linear_issue(access_token, issue["id"], ticket_id)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/linear-update-on-merge.yml
+++ b/.github/workflows/linear-update-on-merge.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Update Linear ticket to Deployed
         uses: ./.github/actions/update-linear-on-merge
         with:
-          linear_api_key: ${{ secrets.LINEAR_API_KEY }}
+          oauth_client_id: ${{ secrets.LINEAR_OAUTH_CLIENT_ID }}
+          oauth_client_secret: ${{ secrets.LINEAR_OAUTH_CLIENT_SECRET }}
           pr_title: ${{ github.event.pull_request.title }}
           pr_branch: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
`Update Linear on Merge` fails on every merged PR that names a ticket ([latest run](https://github.com/eon-io/terraform-provider-eon/actions/runs/30805769706/job/91660669963)):

```
Found Linear ticket: EON-16912
requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://api.linear.app/graphql
```

## Cause

The action authenticates with `LINEAR_API_KEY`, a personal Linear key added on 2026-04-12 and never rotated. Linear rejects it now. The last run that reached the API and succeeded was on the day that secret was created; the 401 reproduces as far back as 2026-07-26 (EON-16210). Every green run in between took the `No Linear ticket ID found ... Skipping` path on dependabot and non-EON branches, so nothing surfaced the breakage — no merged EON ticket has been moved to Deployed by this workflow since April.

## Changes

Same OAuth `client_credentials` flow the Linear actions in `eon-service` already use (`.github/actions/create-linear-issue`, `.github/actions/process-deployed-prs`):

- `update_linear_on_merge.py` gains `get_oauth_access_token()`, which posts the client credentials to `https://api.linear.app/oauth/token` with scope `read,write`; both GraphQL calls now send `Authorization: Bearer <token>`.
- The script reads `OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` from the environment, not argv, so the credentials stay out of `/proc` — the same reason the API key moved to env earlier.
- `action.yml` swaps its `linear_api_key` input for `oauth_client_id` / `oauth_client_secret`; the workflow wires them from `secrets.LINEAR_OAUTH_CLIENT_ID` / `secrets.LINEAR_OAUTH_CLIENT_SECRET`.

Beyond fixing the 401, this takes the workflow off one person's personal key.

## Before this can go green

`LINEAR_OAUTH_CLIENT_ID` and `LINEAR_OAUTH_CLIENT_SECRET` are repo-level secrets on `eon-service`, so this repo cannot see them. They need to be added here (or promoted to org secrets) — otherwise the job fails at the token exchange instead of at the GraphQL call.

## Verification

`test_update_linear_on_merge.py` passes, both YAML files parse, and running the script with the credentials unset exits 1 with `OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET are required.` Merging this PR exercises the new path on its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
