### PR TITLE
fix(terraform-provider): refresh eon_backup_policy selector and plan on read (EON-17010)

### DIFF
--- a/docs/resources/backup_policy.md
+++ b/docs/resources/backup_policy.md
@@ -553,9 +553,9 @@ output "backup_policies_summary" {
 
 ### Read-Only
 
-- `created_at` (String) Creation timestamp
+- `created_at` (String) Time at which Terraform created this policy. Eon does not report policy timestamps, so this records the local apply time and is not refreshed afterwards
 - `id` (String) Backup policy identifier
-- `updated_at` (String) Last update timestamp
+- `updated_at` (String) Time at which Terraform last applied a change to this policy. Eon does not report policy timestamps, so this records the local apply time and is not refreshed afterwards
 
 <a id="nestedatt--backup_plan"></a>
 ### Nested Schema for `backup_plan`

--- a/internal/provider/backup_policy_flatten.go
+++ b/internal/provider/backup_policy_flatten.go
@@ -1,0 +1,1086 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	externalEonSdkAPI "github.com/eon-io/eon-sdk-go"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// monthNames indexes the annually_config month names by their API value, which is a 1-based month
+// number rather than a string enum.
+var monthNames = []string{
+	"JANUARY", "FEBRUARY", "MARCH", "APRIL", "MAY", "JUNE",
+	"JULY", "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER",
+}
+
+func monthName(month int32) (string, error) {
+	if month < 1 || int(month) > len(monthNames) {
+		return "", fmt.Errorf("month %d is out of range 1-12", month)
+	}
+	return monthNames[month-1], nil
+}
+
+func monthNumber(name string) (int32, error) {
+	for i, candidate := range monthNames {
+		if candidate == name {
+			return int32(i + 1), nil
+		}
+	}
+	return 0, fmt.Errorf("month must be one of %s, got %q", strings.Join(monthNames, ", "), name)
+}
+
+func nullOf(t attr.Type) (attr.Value, error) {
+	switch typed := t.(type) {
+	case basetypes.StringType:
+		return types.StringNull(), nil
+	case basetypes.BoolType:
+		return types.BoolNull(), nil
+	case basetypes.Int64Type:
+		return types.Int64Null(), nil
+	case basetypes.ObjectType:
+		return types.ObjectNull(typed.AttrTypes), nil
+	case basetypes.ListType:
+		return types.ListNull(typed.ElemType), nil
+	default:
+		return nil, fmt.Errorf("no null value defined for attribute type %T", t)
+	}
+}
+
+// objectValue builds an object of type t from the attributes the caller resolved, filling the rest
+// with typed nulls. The framework rejects an object whose attribute map does not cover its type
+// exactly, and every condition and schedule variant in this schema leaves most siblings unset.
+func objectValue(t types.ObjectType, present map[string]attr.Value) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	values := make(map[string]attr.Value, len(t.AttrTypes))
+	for name, attrType := range t.AttrTypes {
+		if value, ok := present[name]; ok {
+			values[name] = value
+			continue
+		}
+		nullValue, err := nullOf(attrType)
+		if err != nil {
+			diags.AddError("Backup Policy Refresh Failed", fmt.Sprintf("Cannot build attribute %q: %s", name, err))
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+		values[name] = nullValue
+	}
+
+	for name := range present {
+		if _, ok := t.AttrTypes[name]; !ok {
+			diags.AddError("Backup Policy Refresh Failed", fmt.Sprintf("Attribute %q is not part of the schema", name))
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+	}
+
+	object, objectDiags := types.ObjectValue(t.AttrTypes, values)
+	diags.Append(objectDiags...)
+	return object, diags
+}
+
+// nestedObjectType and nestedListElementType read the shape of a nested attribute off the resource
+// schema instead of restating it here, so the flatten path cannot drift away from the schema.
+func nestedObjectType(t types.ObjectType, name string) (types.ObjectType, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attrType, ok := t.AttrTypes[name]
+	if !ok {
+		diags.AddError("Backup Policy Refresh Failed", fmt.Sprintf("Schema has no attribute %q", name))
+		return types.ObjectType{}, diags
+	}
+	objectType, ok := attrType.(types.ObjectType)
+	if !ok {
+		diags.AddError("Backup Policy Refresh Failed", fmt.Sprintf("Attribute %q is %T, expected an object", name, attrType))
+		return types.ObjectType{}, diags
+	}
+	return objectType, diags
+}
+
+func nestedListElementType(t types.ObjectType, name string) (types.ObjectType, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attrType, ok := t.AttrTypes[name]
+	if !ok {
+		diags.AddError("Backup Policy Refresh Failed", fmt.Sprintf("Schema has no attribute %q", name))
+		return types.ObjectType{}, diags
+	}
+	listType, ok := attrType.(types.ListType)
+	if !ok {
+		diags.AddError("Backup Policy Refresh Failed", fmt.Sprintf("Attribute %q is %T, expected a list", name, attrType))
+		return types.ObjectType{}, diags
+	}
+	elementType, ok := listType.ElemType.(types.ObjectType)
+	if !ok {
+		diags.AddError("Backup Policy Refresh Failed", fmt.Sprintf("Attribute %q holds %T elements, expected objects", name, listType.ElemType))
+		return types.ObjectType{}, diags
+	}
+	return elementType, diags
+}
+
+// priorObject digs an object out of state Terraform already holds. Everything is null after an
+// import, and the flatten path only consults prior values where the API cannot round-trip what the
+// configuration wrote, so a null here is expected rather than an error.
+func priorObject(prior types.Object, name string) types.Object {
+	if prior.IsNull() || prior.IsUnknown() {
+		return types.ObjectNull(nil)
+	}
+	value, ok := prior.Attributes()[name]
+	if !ok {
+		return types.ObjectNull(nil)
+	}
+	object, ok := value.(types.Object)
+	if !ok {
+		return types.ObjectNull(nil)
+	}
+	return object
+}
+
+func priorInt64(prior types.Object, name string) types.Int64 {
+	if prior.IsNull() || prior.IsUnknown() {
+		return types.Int64Null()
+	}
+	value, ok := prior.Attributes()[name]
+	if !ok {
+		return types.Int64Null()
+	}
+	number, ok := value.(types.Int64)
+	if !ok {
+		return types.Int64Null()
+	}
+	return number
+}
+
+func priorList(prior types.Object, name string) types.List {
+	if prior.IsNull() || prior.IsUnknown() {
+		return types.ListNull(types.StringType)
+	}
+	value, ok := prior.Attributes()[name]
+	if !ok {
+		return types.ListNull(types.StringType)
+	}
+	list, ok := value.(types.List)
+	if !ok {
+		return types.ListNull(types.StringType)
+	}
+	return list
+}
+
+// flattenOverrideList maps an override list the API omits when empty. A configuration that wrote an
+// explicit empty list keeps it, since the API cannot distinguish that from an absent list and
+// rewriting it as null would diff on every plan; anything else follows the API.
+func flattenOverrideList(ctx context.Context, values []string, prior types.List) (types.List, diag.Diagnostics) {
+	if len(values) == 0 {
+		if !prior.IsNull() && !prior.IsUnknown() && len(prior.Elements()) == 0 {
+			return prior, nil
+		}
+		return types.ListNull(types.StringType), nil
+	}
+	return types.ListValueFrom(ctx, types.StringType, values)
+}
+
+func priorString(prior types.Object, name string) types.String {
+	if prior.IsNull() || prior.IsUnknown() {
+		return types.StringNull()
+	}
+	value, ok := prior.Attributes()[name]
+	if !ok {
+		return types.StringNull()
+	}
+	text, ok := value.(types.String)
+	if !ok {
+		return types.StringNull()
+	}
+	return text
+}
+
+// priorListElement returns the element that held position index in a prior list attribute, matching
+// schedules to their previous representation by position because they carry no identifier.
+func priorListElement(prior types.Object, name string, index int) types.Object {
+	if prior.IsNull() || prior.IsUnknown() {
+		return types.ObjectNull(nil)
+	}
+	value, ok := prior.Attributes()[name]
+	if !ok {
+		return types.ObjectNull(nil)
+	}
+	list, ok := value.(types.List)
+	if !ok || list.IsNull() || list.IsUnknown() {
+		return types.ObjectNull(nil)
+	}
+	elements := list.Elements()
+	if index >= len(elements) {
+		return types.ObjectNull(nil)
+	}
+	element, ok := elements[index].(types.Object)
+	if !ok {
+		return types.ObjectNull(nil)
+	}
+	return element
+}
+
+func enumStrings[T ~string](values []T) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		result = append(result, string(value))
+	}
+	return result
+}
+
+// flattenBackupPolicy refreshes resource_selector and backup_plan from the API so that changes made
+// outside Terraform surface as drift and an imported policy compares against what Eon holds.
+// created_at and updated_at are deliberately left alone: the API does not carry them, so anything
+// written here would differ on every refresh and show as a permanent diff.
+func flattenBackupPolicy(
+	ctx context.Context,
+	policy *externalEonSdkAPI.BackupPolicy,
+	schemaType types.ObjectType,
+	data *BackupPolicyResourceModel,
+) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	selectorType, typeDiags := nestedObjectType(schemaType, "resource_selector")
+	diags.Append(typeDiags...)
+	planType, typeDiags := nestedObjectType(schemaType, "backup_plan")
+	diags.Append(typeDiags...)
+	if diags.HasError() {
+		return diags
+	}
+
+	selector, selectorDiags := flattenResourceSelector(ctx, selectorType, policy.ResourceSelector, data.ResourceSelector)
+	diags.Append(selectorDiags...)
+
+	plan, planDiags := flattenBackupPlan(ctx, planType, policy.BackupPlan, data.BackupPlan)
+	diags.Append(planDiags...)
+	if diags.HasError() {
+		return diags
+	}
+
+	data.Id = types.StringValue(policy.Id)
+	data.Name = types.StringValue(policy.Name)
+	data.Enabled = types.BoolValue(policy.Enabled)
+	data.ResourceSelector = selector
+	data.BackupPlan = plan
+
+	return diags
+}
+
+func flattenResourceSelector(
+	ctx context.Context,
+	t types.ObjectType,
+	selector externalEonSdkAPI.BackupPolicyResourceSelector,
+	prior types.Object,
+) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	present := map[string]attr.Value{
+		"resource_selection_mode": types.StringValue(string(selector.ResourceSelectionMode)),
+	}
+
+	for name, values := range map[string][]string{
+		"resource_inclusion_override": selector.ResourceInclusionOverride,
+		"resource_exclusion_override": selector.ResourceExclusionOverride,
+	} {
+		override, overrideDiags := flattenOverrideList(ctx, values, priorList(prior, name))
+		diags.Append(overrideDiags...)
+		if !override.IsNull() {
+			present[name] = override
+		}
+	}
+
+	if expression := selector.Expression.Get(); expression != nil {
+		expressionType, typeDiags := nestedObjectType(t, "expression")
+		diags.Append(typeDiags...)
+		if diags.HasError() {
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+
+		flattened, expressionDiags := flattenExpression(ctx, expressionType, *expression, priorObject(prior, "expression"))
+		diags.Append(expressionDiags...)
+		present["expression"] = flattened
+	}
+
+	if diags.HasError() {
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	object, objectDiags := objectValue(t, present)
+	diags.Append(objectDiags...)
+	return object, diags
+}
+
+// unrepresentableConditions reports the conditions Eon returned that this provider's schema has no
+// attribute for. Silently dropping them would refresh the resource into a state the configuration
+// can never reproduce, which reads as an unfixable diff on every plan.
+func unrepresentableConditions(expression externalEonSdkAPI.BackupPolicyExpression, supported map[string]bool) []string {
+	candidates := map[string]bool{
+		"group":                         expression.Group.Get() != nil,
+		"resource_type":                 expression.ResourceType.Get() != nil,
+		"data_classes":                  expression.DataClasses.Get() != nil,
+		"environment":                   expression.Environment.Get() != nil,
+		"apps":                          expression.Apps.Get() != nil,
+		"cloud_provider":                expression.CloudProvider.Get() != nil,
+		"account_id":                    expression.AccountId.Get() != nil,
+		"source_region":                 expression.SourceRegion.Get() != nil,
+		"vpc":                           expression.Vpc.Get() != nil,
+		"subnets":                       expression.Subnets.Get() != nil,
+		"resource_group_name":           expression.ResourceGroupName.Get() != nil,
+		"resource_name":                 expression.ResourceName.Get() != nil,
+		"resource_id":                   expression.ResourceId.Get() != nil,
+		"tag_keys":                      expression.TagKeys.Get() != nil,
+		"tag_key_values":                expression.TagKeyValues.Get() != nil,
+		"source_account_tag_keys":       expression.SourceAccountTagKeys.Get() != nil,
+		"source_account_tag_key_values": expression.SourceAccountTagKeyValues.Get() != nil,
+		"global_cluster_identifier":     expression.GlobalClusterIdentifier.Get() != nil,
+	}
+
+	var unrepresentable []string
+	for name, set := range candidates {
+		if set && !supported[name] {
+			unrepresentable = append(unrepresentable, name)
+		}
+	}
+	return unrepresentable
+}
+
+func flattenExpression(
+	ctx context.Context,
+	t types.ObjectType,
+	expression externalEonSdkAPI.BackupPolicyExpression,
+	prior types.Object,
+) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	supported := map[string]bool{"environment": true, "resource_type": true, "tag_keys": true, "tag_key_values": true, "group": true}
+	if unrepresentable := unrepresentableConditions(expression, supported); len(unrepresentable) > 0 {
+		diags.AddError(
+			"Unsupported Backup Policy Condition",
+			fmt.Sprintf("Eon returned the condition(s) %s at the top level of resource_selector.expression. "+
+				"This provider version can only represent %s there; nest the others inside a group condition, "+
+				"or upgrade the provider.",
+				strings.Join(unrepresentable, ", "), "environment, resource_type, tag_keys, tag_key_values, group"),
+		)
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	present := map[string]attr.Value{}
+
+	if condition := expression.Environment.Get(); condition != nil {
+		flattened, conditionDiags := flattenValuesCondition(ctx, t, "environment", string(condition.Operator), enumStrings(condition.Environments))
+		diags.Append(conditionDiags...)
+		present["environment"] = flattened
+	}
+
+	if condition := expression.ResourceType.Get(); condition != nil {
+		flattened, conditionDiags := flattenValuesCondition(ctx, t, "resource_type", string(condition.Operator), enumStrings(condition.ResourceTypes))
+		diags.Append(conditionDiags...)
+		present["resource_type"] = flattened
+	}
+
+	if condition := expression.TagKeys.Get(); condition != nil {
+		flattened, conditionDiags := flattenValuesCondition(ctx, t, "tag_keys", string(condition.Operator), condition.TagKeys)
+		diags.Append(conditionDiags...)
+		present["tag_keys"] = flattened
+	}
+
+	if condition := expression.TagKeyValues.Get(); condition != nil {
+		flattened, conditionDiags := flattenTagKeyValuesCondition(t, "tag_key_values", *condition)
+		diags.Append(conditionDiags...)
+		present["tag_key_values"] = flattened
+	}
+
+	if condition := expression.Group.Get(); condition != nil {
+		groupType, typeDiags := nestedObjectType(t, "group")
+		diags.Append(typeDiags...)
+		if diags.HasError() {
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+
+		flattened, groupDiags := flattenGroupCondition(ctx, groupType, *condition, priorObject(prior, "group"))
+		diags.Append(groupDiags...)
+		present["group"] = flattened
+	}
+
+	if diags.HasError() {
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	object, objectDiags := objectValue(t, present)
+	diags.Append(objectDiags...)
+	return object, diags
+}
+
+func flattenGroupCondition(
+	ctx context.Context,
+	t types.ObjectType,
+	group externalEonSdkAPI.BackupPolicyGroupCondition,
+	prior types.Object,
+) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	operandType, typeDiags := nestedListElementType(t, "operands")
+	diags.Append(typeDiags...)
+	if diags.HasError() {
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	operands := make([]attr.Value, 0, len(group.Operands))
+	for _, operand := range group.Operands {
+		flattened, operandDiags := flattenOperand(ctx, operandType, operand)
+		diags.Append(operandDiags...)
+		if diags.HasError() {
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+		operands = append(operands, flattened)
+	}
+
+	operandList, listDiags := types.ListValue(operandType, operands)
+	diags.Append(listDiags...)
+	if diags.HasError() {
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	object, objectDiags := objectValue(t, map[string]attr.Value{
+		"operator": types.StringValue(string(group.Operator)),
+		"operands": operandList,
+	})
+	diags.Append(objectDiags...)
+	return object, diags
+}
+
+func flattenOperand(
+	ctx context.Context,
+	t types.ObjectType,
+	operand externalEonSdkAPI.BackupPolicyExpression,
+) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	supported := map[string]bool{
+		"resource_type": true, "environment": true, "tag_keys": true, "tag_key_values": true,
+		"data_classes": true, "apps": true, "cloud_provider": true, "account_id": true,
+		"source_region": true, "vpc": true, "subnets": true, "resource_group_name": true,
+		"resource_name": true, "resource_id": true,
+	}
+	if unrepresentable := unrepresentableConditions(operand, supported); len(unrepresentable) > 0 {
+		diags.AddError(
+			"Unsupported Backup Policy Condition",
+			fmt.Sprintf("Eon returned the condition(s) %s inside a group operand. This provider version "+
+				"cannot represent them; upgrade the provider to manage this policy with Terraform.",
+				strings.Join(unrepresentable, ", ")),
+		)
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	present := map[string]attr.Value{}
+
+	// Every operand condition is an {operator, <values>} pair, so they only differ in where the
+	// values come from on the API type.
+	type valuesCondition struct {
+		name     string
+		operator string
+		values   []string
+	}
+	var conditions []valuesCondition
+
+	if condition := operand.ResourceType.Get(); condition != nil {
+		conditions = append(conditions, valuesCondition{"resource_type", string(condition.Operator), enumStrings(condition.ResourceTypes)})
+	}
+	if condition := operand.Environment.Get(); condition != nil {
+		conditions = append(conditions, valuesCondition{"environment", string(condition.Operator), enumStrings(condition.Environments)})
+	}
+	if condition := operand.TagKeys.Get(); condition != nil {
+		conditions = append(conditions, valuesCondition{"tag_keys", string(condition.Operator), condition.TagKeys})
+	}
+	if condition := operand.DataClasses.Get(); condition != nil {
+		conditions = append(conditions, valuesCondition{"data_classes", string(condition.Operator), condition.DataClasses})
+	}
+	if condition := operand.Apps.Get(); condition != nil {
+		conditions = append(conditions, valuesCondition{"apps", string(condition.Operator), condition.Apps})
+	}
+	if condition := operand.CloudProvider.Get(); condition != nil {
+		conditions = append(conditions, valuesCondition{"cloud_provider", string(condition.Operator), enumStrings(condition.CloudProviders)})
+	}
+	if condition := operand.AccountId.Get(); condition != nil {
+		conditions = append(conditions, valuesCondition{"account_id", string(condition.Operator), condition.AccountIds})
+	}
+	if condition := operand.SourceRegion.Get(); condition != nil {
+		conditions = append(conditions, valuesCondition{"source_region", string(condition.Operator), condition.Regions})
+	}
+	if condition := operand.Vpc.Get(); condition != nil {
+		conditions = append(conditions, valuesCondition{"vpc", string(condition.Operator), condition.Vpcs})
+	}
+	if condition := operand.Subnets.Get(); condition != nil {
+		conditions = append(conditions, valuesCondition{"subnets", string(condition.Operator), condition.Subnets})
+	}
+	if condition := operand.ResourceGroupName.Get(); condition != nil {
+		conditions = append(conditions, valuesCondition{"resource_group_name", string(condition.Operator), condition.ResourceGroupNames})
+	}
+	if condition := operand.ResourceName.Get(); condition != nil {
+		conditions = append(conditions, valuesCondition{"resource_name", string(condition.Operator), condition.ResourceNames})
+	}
+	if condition := operand.ResourceId.Get(); condition != nil {
+		conditions = append(conditions, valuesCondition{"resource_id", string(condition.Operator), condition.ResourceIds})
+	}
+
+	for _, condition := range conditions {
+		flattened, conditionDiags := flattenValuesCondition(ctx, t, condition.name, condition.operator, condition.values)
+		diags.Append(conditionDiags...)
+		present[condition.name] = flattened
+	}
+
+	if condition := operand.TagKeyValues.Get(); condition != nil {
+		flattened, conditionDiags := flattenTagKeyValuesCondition(t, "tag_key_values", *condition)
+		diags.Append(conditionDiags...)
+		present["tag_key_values"] = flattened
+	}
+
+	if diags.HasError() {
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	object, objectDiags := objectValue(t, present)
+	diags.Append(objectDiags...)
+	return object, diags
+}
+
+// flattenValuesCondition builds a condition object from its operator and values. Each condition in
+// the schema holds exactly an operator plus one list whose name varies per condition
+// (environments, resource_types, vpcs, ...), so the list attribute is the non-operator one.
+func flattenValuesCondition(
+	ctx context.Context,
+	parent types.ObjectType,
+	name string,
+	operator string,
+	values []string,
+) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	conditionType, typeDiags := nestedObjectType(parent, name)
+	diags.Append(typeDiags...)
+	if diags.HasError() {
+		return types.ObjectNull(nil), diags
+	}
+
+	valuesField := ""
+	for attrName := range conditionType.AttrTypes {
+		if attrName != "operator" {
+			valuesField = attrName
+		}
+	}
+	if valuesField == "" {
+		diags.AddError("Backup Policy Refresh Failed", fmt.Sprintf("Condition %q has no values attribute", name))
+		return types.ObjectNull(conditionType.AttrTypes), diags
+	}
+
+	list, listDiags := types.ListValueFrom(ctx, types.StringType, values)
+	diags.Append(listDiags...)
+	if diags.HasError() {
+		return types.ObjectNull(conditionType.AttrTypes), diags
+	}
+
+	object, objectDiags := objectValue(conditionType, map[string]attr.Value{
+		"operator":  types.StringValue(operator),
+		valuesField: list,
+	})
+	diags.Append(objectDiags...)
+	return object, diags
+}
+
+func flattenTagKeyValuesCondition(
+	parent types.ObjectType,
+	name string,
+	condition externalEonSdkAPI.TagKeyValuesCondition,
+) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	conditionType, typeDiags := nestedObjectType(parent, name)
+	diags.Append(typeDiags...)
+	if diags.HasError() {
+		return types.ObjectNull(nil), diags
+	}
+
+	pairType, typeDiags := nestedListElementType(conditionType, "tag_key_values")
+	diags.Append(typeDiags...)
+	if diags.HasError() {
+		return types.ObjectNull(conditionType.AttrTypes), diags
+	}
+
+	pairs := make([]attr.Value, 0, len(condition.TagKeyValues))
+	for _, tagKeyValue := range condition.TagKeyValues {
+		pair, pairDiags := objectValue(pairType, map[string]attr.Value{
+			"key":   types.StringValue(tagKeyValue.Key),
+			"value": types.StringValue(tagKeyValue.GetValue()),
+		})
+		diags.Append(pairDiags...)
+		if diags.HasError() {
+			return types.ObjectNull(conditionType.AttrTypes), diags
+		}
+		pairs = append(pairs, pair)
+	}
+
+	pairList, listDiags := types.ListValue(pairType, pairs)
+	diags.Append(listDiags...)
+	if diags.HasError() {
+		return types.ObjectNull(conditionType.AttrTypes), diags
+	}
+
+	object, objectDiags := objectValue(conditionType, map[string]attr.Value{
+		"operator":       types.StringValue(string(condition.Operator)),
+		"tag_key_values": pairList,
+	})
+	diags.Append(objectDiags...)
+	return object, diags
+}
+
+func flattenBackupPlan(
+	ctx context.Context,
+	t types.ObjectType,
+	plan externalEonSdkAPI.BackupPolicyPlan,
+	prior types.Object,
+) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	policyType := string(plan.BackupPolicyType)
+	present := map[string]attr.Value{"backup_policy_type": types.StringValue(policyType)}
+
+	switch policyType {
+	case "STANDARD", "PITR":
+		standard := plan.StandardPlan.Get()
+		if standard == nil {
+			diags.AddError("Backup Policy Refresh Failed", fmt.Sprintf("Eon reported policy type %s without a standard plan", policyType))
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+
+		standardType, typeDiags := nestedObjectType(t, "standard_plan")
+		diags.Append(typeDiags...)
+		if diags.HasError() {
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+
+		flattened, standardDiags := flattenStandardPlan(ctx, standardType, *standard, priorObject(prior, "standard_plan"))
+		diags.Append(standardDiags...)
+		present["standard_plan"] = flattened
+
+	case "HIGH_FREQUENCY":
+		highFrequency := plan.HighFrequencyPlan.Get()
+		if highFrequency == nil {
+			diags.AddError("Backup Policy Refresh Failed", "Eon reported policy type HIGH_FREQUENCY without a high frequency plan")
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+
+		highFrequencyType, typeDiags := nestedObjectType(t, "high_frequency_plan")
+		diags.Append(typeDiags...)
+		if diags.HasError() {
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+
+		flattened, highFrequencyDiags := flattenHighFrequencyPlan(ctx, highFrequencyType, *highFrequency, priorObject(prior, "high_frequency_plan"))
+		diags.Append(highFrequencyDiags...)
+		present["high_frequency_plan"] = flattened
+
+	case "AWS_NATIVE_PITR":
+		awsNativePitr := plan.AwsNativePitrPlan.Get()
+		if awsNativePitr == nil {
+			diags.AddError("Backup Policy Refresh Failed", "Eon reported policy type AWS_NATIVE_PITR without an AWS native PITR plan")
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+
+		awsNativePitrType, typeDiags := nestedObjectType(t, "aws_native_pitr_plan")
+		diags.Append(typeDiags...)
+		if diags.HasError() {
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+
+		flattened, awsNativePitrDiags := objectValue(awsNativePitrType, map[string]attr.Value{
+			"retention_days": types.Int64Value(int64(awsNativePitr.RetentionDays)),
+			"resource_type":  types.StringValue(string(awsNativePitr.ResourceType.GetResourceType())),
+		})
+		diags.Append(awsNativePitrDiags...)
+		present["aws_native_pitr_plan"] = flattened
+
+	default:
+		diags.AddError(
+			"Unsupported Backup Policy Type",
+			fmt.Sprintf("Eon reports this policy as type '%s', which this provider version cannot represent. "+
+				"Supported types: STANDARD, PITR, HIGH_FREQUENCY, AWS_NATIVE_PITR.", policyType),
+		)
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	if diags.HasError() {
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	object, objectDiags := objectValue(t, present)
+	diags.Append(objectDiags...)
+	return object, diags
+}
+
+func flattenStandardPlan(
+	ctx context.Context,
+	t types.ObjectType,
+	plan externalEonSdkAPI.StandardBackupPolicyPlan,
+	prior types.Object,
+) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	scheduleType, typeDiags := nestedListElementType(t, "backup_schedules")
+	diags.Append(typeDiags...)
+	if diags.HasError() {
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	configType, typeDiags := nestedObjectType(scheduleType, "schedule_config")
+	diags.Append(typeDiags...)
+	if diags.HasError() {
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	schedules := make([]attr.Value, 0, len(plan.BackupSchedules))
+	for index, schedule := range plan.BackupSchedules {
+		priorSchedule := priorListElement(prior, "backup_schedules", index)
+
+		config, configDiags := flattenStandardScheduleConfig(configType, schedule.ScheduleConfig, priorObject(priorSchedule, "schedule_config"))
+		diags.Append(configDiags...)
+		if diags.HasError() {
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+
+		flattened, scheduleDiags := objectValue(scheduleType, map[string]attr.Value{
+			"vault_id":        types.StringValue(schedule.VaultId),
+			"retention_days":  types.Int64Value(int64(schedule.BackupRetentionDays)),
+			"schedule_config": config,
+		})
+		diags.Append(scheduleDiags...)
+		if diags.HasError() {
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+		schedules = append(schedules, flattened)
+	}
+
+	scheduleList, listDiags := types.ListValue(scheduleType, schedules)
+	diags.Append(listDiags...)
+	if diags.HasError() {
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	present := map[string]attr.Value{"backup_schedules": scheduleList}
+	if timezone := flattenScheduleTimezone(plan.ScheduleTimezone, priorString(prior, "schedule_timezone")); !timezone.IsNull() {
+		present["schedule_timezone"] = timezone
+	}
+
+	object, objectDiags := objectValue(t, present)
+	diags.Append(objectDiags...)
+	return object, diags
+}
+
+// flattenScheduleTimezone keeps schedule_timezone null when the configuration omitted it and Eon
+// reports its UTC default, so an unset optional attribute does not read as drift on every plan.
+func flattenScheduleTimezone(timezone *externalEonSdkAPI.ScheduleTimezone, prior types.String) types.String {
+	if timezone == nil {
+		return types.StringNull()
+	}
+	if prior.IsNull() && *timezone == externalEonSdkAPI.SCHEDULE_TIMEZONE_UTC {
+		return types.StringNull()
+	}
+	return types.StringValue(string(*timezone))
+}
+
+func flattenStandardScheduleConfig(
+	t types.ObjectType,
+	config externalEonSdkAPI.StandardBackupScheduleConfig,
+	prior types.Object,
+) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	frequency := string(config.Frequency)
+	present := map[string]attr.Value{"frequency": types.StringValue(frequency)}
+
+	switch config.Frequency {
+	case externalEonSdkAPI.STANDARD_BACKUP_SCHEDULE_DAILY:
+		daily := config.DailyConfig.Get()
+		if daily == nil {
+			break
+		}
+		dailyType, typeDiags := nestedObjectType(t, "daily_config")
+		diags.Append(typeDiags...)
+		if diags.HasError() {
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+		flattened, dailyDiags := objectValue(dailyType, timeOfDayAttrs(daily.TimeOfDay, daily.StartWindowMinutes))
+		diags.Append(dailyDiags...)
+		present["daily_config"] = flattened
+
+	case externalEonSdkAPI.STANDARD_BACKUP_SCHEDULE_WEEKLY:
+		weekly := config.WeeklyConfig.Get()
+		if weekly == nil {
+			break
+		}
+		if len(weekly.DaysOfWeek) > 1 {
+			diags.AddError(
+				"Unsupported Backup Schedule",
+				fmt.Sprintf("Eon reports this weekly schedule on %d days of the week. This provider version "+
+					"models a single day_of_week; upgrade the provider to manage this policy with Terraform.",
+					len(weekly.DaysOfWeek)),
+			)
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+		weeklyType, typeDiags := nestedObjectType(t, "weekly_config")
+		diags.Append(typeDiags...)
+		if diags.HasError() {
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+		attrs := timeOfDayAttrs(&weekly.TimeOfDay, weekly.StartWindowMinutes)
+		if len(weekly.DaysOfWeek) == 1 {
+			attrs["day_of_week"] = types.StringValue(string(weekly.DaysOfWeek[0]))
+		}
+		flattened, weeklyDiags := objectValue(weeklyType, attrs)
+		diags.Append(weeklyDiags...)
+		present["weekly_config"] = flattened
+
+	case externalEonSdkAPI.STANDARD_BACKUP_SCHEDULE_MONTHLY:
+		monthly := config.MonthlyConfig.Get()
+		if monthly == nil {
+			break
+		}
+		if len(monthly.DaysOfMonth) > 1 {
+			diags.AddError(
+				"Unsupported Backup Schedule",
+				fmt.Sprintf("Eon reports this monthly schedule on %d days of the month. This provider version "+
+					"models a single day_of_month; upgrade the provider to manage this policy with Terraform.",
+					len(monthly.DaysOfMonth)),
+			)
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+		monthlyType, typeDiags := nestedObjectType(t, "monthly_config")
+		diags.Append(typeDiags...)
+		if diags.HasError() {
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+		priorMonthly := priorObject(prior, "monthly_config")
+		dayOfMonth := priorInt64(priorMonthly, "day_of_month")
+		if len(monthly.DaysOfMonth) == 1 {
+			dayOfMonth = types.Int64Value(int64(monthly.DaysOfMonth[0]))
+		}
+		attrs := timeOfDayAttrs(monthly.TimeOfDay, monthly.StartWindowMinutes)
+		attrs["day_of_month"] = dayOfMonth
+		flattened, monthlyDiags := objectValue(monthlyType, attrs)
+		diags.Append(monthlyDiags...)
+		present["monthly_config"] = flattened
+
+	case externalEonSdkAPI.STANDARD_BACKUP_SCHEDULE_ANNUALLY:
+		annually := config.AnnuallyConfig.Get()
+		if annually == nil {
+			break
+		}
+		annuallyType, typeDiags := nestedObjectType(t, "annually_config")
+		diags.Append(typeDiags...)
+		if diags.HasError() {
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+		priorAnnually := priorObject(prior, "annually_config")
+		attrs := timeOfDayAttrs(annually.TimeOfDay, annually.StartWindowMinutes)
+		attrs["month"] = priorString(priorAnnually, "month")
+		attrs["day_of_month"] = priorInt64(priorAnnually, "day_of_month")
+		if timeOfYear := annually.TimeOfYear; timeOfYear != nil {
+			name, err := monthName(timeOfYear.Month)
+			if err != nil {
+				diags.AddError("Backup Policy Refresh Failed", fmt.Sprintf("Eon returned an unusable annual schedule: %s", err))
+				return types.ObjectNull(t.AttrTypes), diags
+			}
+			attrs["month"] = types.StringValue(name)
+			attrs["day_of_month"] = types.Int64Value(int64(timeOfYear.DayOfMonth))
+		}
+		flattened, annuallyDiags := objectValue(annuallyType, attrs)
+		diags.Append(annuallyDiags...)
+		present["annually_config"] = flattened
+
+	case externalEonSdkAPI.STANDARD_BACKUP_SCHEDULE_INTERVAL:
+		interval := config.IntervalConfig.Get()
+		if interval == nil {
+			break
+		}
+		intervalType, typeDiags := nestedObjectType(t, "interval_config")
+		diags.Append(typeDiags...)
+		if diags.HasError() {
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+		flattened, intervalDiags := flattenIntervalConfig(intervalType, int64(interval.IntervalHours)*60, priorObject(prior, "interval_config"))
+		diags.Append(intervalDiags...)
+		present["interval_config"] = flattened
+
+	default:
+		diags.AddError(
+			"Unsupported Backup Schedule",
+			fmt.Sprintf("Eon reports this schedule with frequency '%s', which this provider version cannot "+
+				"represent. Supported frequencies: DAILY, WEEKLY, MONTHLY, ANNUALLY, INTERVAL.", frequency),
+		)
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	if diags.HasError() {
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	object, objectDiags := objectValue(t, present)
+	diags.Append(objectDiags...)
+	return object, diags
+}
+
+// timeOfDayAttrs maps the API's optional time-of-day and start window onto the attribute names every
+// schedule config variant shares.
+func timeOfDayAttrs(timeOfDay *externalEonSdkAPI.TimeOfDay, startWindowMinutes *int32) map[string]attr.Value {
+	attrs := map[string]attr.Value{}
+	if timeOfDay != nil {
+		attrs["time_of_day_hour"] = types.Int64Value(int64(timeOfDay.Hour))
+		attrs["time_of_day_minutes"] = types.Int64Value(int64(timeOfDay.Minute))
+	}
+	if startWindowMinutes != nil {
+		attrs["start_window_minutes"] = types.Int64Value(int64(*startWindowMinutes))
+	}
+	return attrs
+}
+
+// flattenIntervalConfig reports the interval in whichever unit the configuration used, because
+// interval_minutes and interval_hours describe the same interval and rewriting one as the other
+// would show as permanent drift. start_window_minutes has no field on either interval config in the
+// API, so the prior value is carried over rather than being cleared on every refresh.
+func flattenIntervalConfig(t types.ObjectType, intervalMinutes int64, prior types.Object) (types.Object, diag.Diagnostics) {
+	present := map[string]attr.Value{}
+
+	if startWindow := priorInt64(prior, "start_window_minutes"); !startWindow.IsNull() {
+		present["start_window_minutes"] = startWindow
+	}
+
+	priorHours := priorInt64(prior, "interval_hours")
+	if !priorHours.IsNull() && priorHours.ValueInt64()*60 == intervalMinutes {
+		present["interval_hours"] = priorHours
+		return objectValue(t, present)
+	}
+
+	priorMinutes := priorInt64(prior, "interval_minutes")
+	if !priorMinutes.IsNull() && priorMinutes.ValueInt64() == intervalMinutes {
+		present["interval_minutes"] = priorMinutes
+		return objectValue(t, present)
+	}
+
+	// Nothing in state to match: report hours when the interval divides evenly, since that is the
+	// unit the API itself stores for standard schedules.
+	if intervalMinutes%60 == 0 {
+		present["interval_hours"] = types.Int64Value(intervalMinutes / 60)
+	} else {
+		present["interval_minutes"] = types.Int64Value(intervalMinutes)
+	}
+	return objectValue(t, present)
+}
+
+func flattenHighFrequencyPlan(
+	ctx context.Context,
+	t types.ObjectType,
+	plan externalEonSdkAPI.HighFrequencyBackupPolicyPlan,
+	prior types.Object,
+) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	resourceTypes := make([]string, 0, len(plan.ResourceTypes))
+	for _, resourceType := range plan.ResourceTypes {
+		resourceTypes = append(resourceTypes, string(resourceType.GetResourceType()))
+	}
+	resourceTypeList, listDiags := types.ListValueFrom(ctx, types.StringType, resourceTypes)
+	diags.Append(listDiags...)
+
+	scheduleType, typeDiags := nestedListElementType(t, "backup_schedules")
+	diags.Append(typeDiags...)
+	if diags.HasError() {
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	configType, typeDiags := nestedObjectType(scheduleType, "schedule_config")
+	diags.Append(typeDiags...)
+	if diags.HasError() {
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	schedules := make([]attr.Value, 0, len(plan.BackupSchedules))
+	for index, schedule := range plan.BackupSchedules {
+		priorSchedule := priorListElement(prior, "backup_schedules", index)
+
+		config, configDiags := flattenHighFrequencyScheduleConfig(configType, schedule.ScheduleConfig, priorObject(priorSchedule, "schedule_config"))
+		diags.Append(configDiags...)
+		if diags.HasError() {
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+
+		flattened, scheduleDiags := objectValue(scheduleType, map[string]attr.Value{
+			"vault_id":        types.StringValue(schedule.VaultId),
+			"retention_days":  types.Int64Value(int64(schedule.BackupRetentionDays)),
+			"schedule_config": config,
+		})
+		diags.Append(scheduleDiags...)
+		if diags.HasError() {
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+		schedules = append(schedules, flattened)
+	}
+
+	scheduleList, listDiags := types.ListValue(scheduleType, schedules)
+	diags.Append(listDiags...)
+	if diags.HasError() {
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	object, objectDiags := objectValue(t, map[string]attr.Value{
+		"resource_types":   resourceTypeList,
+		"backup_schedules": scheduleList,
+	})
+	diags.Append(objectDiags...)
+	return object, diags
+}
+
+func flattenHighFrequencyScheduleConfig(
+	t types.ObjectType,
+	config externalEonSdkAPI.HighFrequencyBackupScheduleConfig,
+	prior types.Object,
+) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	frequency := config.GetFrequency()
+	if frequency != externalEonSdkAPI.HIGH_FREQUENCY_BACKUP_SCHEDULE_INTERVAL {
+		diags.AddError(
+			"Unsupported Backup Schedule",
+			fmt.Sprintf("Eon reports this high frequency schedule with frequency '%s'. This provider version "+
+				"only models INTERVAL high frequency schedules.", string(frequency)),
+		)
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	interval := config.IntervalConfig.Get()
+	if interval == nil {
+		diags.AddError("Backup Policy Refresh Failed", "Eon reported an INTERVAL high frequency schedule without an interval config")
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	intervalType, typeDiags := nestedObjectType(t, "interval_config")
+	diags.Append(typeDiags...)
+	if diags.HasError() {
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	intervalConfig, intervalDiags := flattenIntervalConfig(intervalType, int64(interval.IntervalMinutes), priorObject(prior, "interval_config"))
+	diags.Append(intervalDiags...)
+	if diags.HasError() {
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	object, objectDiags := objectValue(t, map[string]attr.Value{
+		"frequency":       types.StringValue(string(frequency)),
+		"interval_config": intervalConfig,
+	})
+	diags.Append(objectDiags...)
+	return object, diags
+}

--- a/internal/provider/backup_policy_flatten_test.go
+++ b/internal/provider/backup_policy_flatten_test.go
@@ -1,0 +1,401 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	externalEonSdkAPI "github.com/eon-io/eon-sdk-go"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func policySchemaType(t *testing.T) types.ObjectType {
+	t.Helper()
+
+	policyResource := &BackupPolicyResource{}
+	schemaType, ok := policyResource.schemaObjectType(context.Background())
+	require.True(t, ok, "backup policy schema should be an object type")
+	return schemaType
+}
+
+// nestedValue walks an object value along a path of attribute names, stepping into the element at
+// index 0 whenever it meets a list, which is enough to reach any value these tests assert on.
+func nestedValue(t *testing.T, object types.Object, path ...string) attr.Value {
+	t.Helper()
+
+	var current attr.Value = object
+	for _, name := range path {
+		if list, ok := current.(types.List); ok {
+			elements := list.Elements()
+			require.NotEmpty(t, elements, "list before %q is empty", name)
+			current = elements[0]
+		}
+
+		parent, ok := current.(types.Object)
+		require.True(t, ok, "value before %q is %T, expected an object", name, current)
+		require.False(t, parent.IsNull(), "object before %q is null", name)
+
+		value, ok := parent.Attributes()[name]
+		require.True(t, ok, "no attribute %q", name)
+		current = value
+	}
+	return current
+}
+
+func standardPolicy(scheduleConfig externalEonSdkAPI.StandardBackupScheduleConfig) *externalEonSdkAPI.BackupPolicy {
+	selector := externalEonSdkAPI.NewBackupPolicyResourceSelector(externalEonSdkAPI.RESOURCE_SELECTOR_MODE_ALL)
+	schedule := externalEonSdkAPI.NewStandardBackupSchedules("vault-1", scheduleConfig, 30)
+	standardPlan := externalEonSdkAPI.NewStandardBackupPolicyPlan([]externalEonSdkAPI.StandardBackupSchedules{*schedule})
+	plan := externalEonSdkAPI.NewBackupPolicyPlan(externalEonSdkAPI.BACKUP_POLICY_TYPE_STANDARD)
+	plan.SetStandardPlan(*standardPlan)
+
+	return externalEonSdkAPI.NewBackupPolicy("policy-1", "nightly", true, *selector, *plan)
+}
+
+func dailyScheduleConfig(hour, minute int32) externalEonSdkAPI.StandardBackupScheduleConfig {
+	dailyConfig := externalEonSdkAPI.NewDailyConfig()
+	dailyConfig.SetTimeOfDay(*externalEonSdkAPI.NewTimeOfDay(hour, minute))
+
+	scheduleConfig := externalEonSdkAPI.NewStandardBackupScheduleConfig(externalEonSdkAPI.STANDARD_BACKUP_SCHEDULE_DAILY)
+	scheduleConfig.SetDailyConfig(*dailyConfig)
+	return *scheduleConfig
+}
+
+// TestFlattenBackupPolicy_RefreshesSelectorAndPlan covers the drift gap this file exists for: Read
+// used to carry resource_selector and backup_plan over from prior state, so console-side edits never
+// produced a plan diff (EON-16210).
+func TestFlattenBackupPolicy_RefreshesSelectorAndPlan(t *testing.T) {
+	t.Parallel()
+
+	schemaType := policySchemaType(t)
+	policy := standardPolicy(dailyScheduleConfig(3, 15))
+
+	data := BackupPolicyResourceModel{}
+	diags := flattenBackupPolicy(context.Background(), policy, schemaType, &data)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags.Errors())
+
+	assert.Equal(t, "policy-1", data.Id.ValueString())
+	assert.Equal(t, "nightly", data.Name.ValueString())
+	assert.True(t, data.Enabled.ValueBool())
+
+	assert.Equal(t, types.StringValue("ALL"), nestedValue(t, data.ResourceSelector, "resource_selection_mode"))
+	assert.Equal(t, types.StringValue("STANDARD"), nestedValue(t, data.BackupPlan, "backup_policy_type"))
+	assert.Equal(t, types.StringValue("vault-1"), nestedValue(t, data.BackupPlan, "standard_plan", "backup_schedules", "vault_id"))
+	assert.Equal(t, types.Int64Value(30), nestedValue(t, data.BackupPlan, "standard_plan", "backup_schedules", "retention_days"))
+	assert.Equal(t, types.Int64Value(3), nestedValue(t, data.BackupPlan, "standard_plan", "backup_schedules", "schedule_config", "daily_config", "time_of_day_hour"))
+	assert.Equal(t, types.Int64Value(15), nestedValue(t, data.BackupPlan, "standard_plan", "backup_schedules", "schedule_config", "daily_config", "time_of_day_minutes"))
+
+	// Terraform-only bookkeeping: the API carries no timestamps, so refresh must not invent new ones.
+	assert.True(t, data.CreatedAt.IsNull())
+	assert.True(t, data.UpdatedAt.IsNull())
+}
+
+func TestFlattenBackupPolicy_GroupExpression(t *testing.T) {
+	t.Parallel()
+
+	operand := externalEonSdkAPI.NewBackupPolicyExpression()
+	operand.SetResourceName(*externalEonSdkAPI.NewResourceNameCondition(
+		externalEonSdkAPI.StringOperators("STARTS_WITH"), []string{"prod-"}))
+
+	group := externalEonSdkAPI.NewBackupPolicyGroupCondition(
+		externalEonSdkAPI.AND_OPERATOR, []externalEonSdkAPI.BackupPolicyExpression{*operand})
+
+	expression := externalEonSdkAPI.NewBackupPolicyExpression()
+	expression.SetGroup(*group)
+
+	policy := standardPolicy(dailyScheduleConfig(1, 0))
+	policy.ResourceSelector.ResourceSelectionMode = externalEonSdkAPI.RESOURCE_SELECTOR_MODE_CONDITIONAL
+	policy.ResourceSelector.SetExpression(*expression)
+
+	data := BackupPolicyResourceModel{}
+	diags := flattenBackupPolicy(context.Background(), policy, policySchemaType(t), &data)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags.Errors())
+
+	assert.Equal(t, types.StringValue("AND"), nestedValue(t, data.ResourceSelector, "expression", "group", "operator"))
+	assert.Equal(t, types.StringValue("STARTS_WITH"),
+		nestedValue(t, data.ResourceSelector, "expression", "group", "operands", "resource_name", "operator"))
+
+	names, ok := nestedValue(t, data.ResourceSelector, "expression", "group", "operands", "resource_name", "resource_names").(types.List)
+	require.True(t, ok)
+	assert.Equal(t, []attr.Value{types.StringValue("prod-")}, names.Elements())
+}
+
+// TestFlattenBackupPolicy_RejectsUnrepresentableCondition guards the other half of drift detection:
+// silently dropping a condition the schema cannot express would refresh the resource into a state no
+// configuration can reproduce, which reads as an undiffable plan forever.
+func TestFlattenBackupPolicy_RejectsUnrepresentableCondition(t *testing.T) {
+	t.Parallel()
+
+	expression := externalEonSdkAPI.NewBackupPolicyExpression()
+	expression.SetResourceName(*externalEonSdkAPI.NewResourceNameCondition(
+		externalEonSdkAPI.StringOperators("CONTAINS"), []string{"db"}))
+
+	policy := standardPolicy(dailyScheduleConfig(1, 0))
+	policy.ResourceSelector.SetExpression(*expression)
+
+	data := BackupPolicyResourceModel{}
+	diags := flattenBackupPolicy(context.Background(), policy, policySchemaType(t), &data)
+	require.True(t, diags.HasError(), "top-level resource_name should be rejected")
+	assert.Contains(t, diags.Errors()[0].Detail(), "resource_name")
+}
+
+func TestFlattenBackupPolicy_RejectsUnsupportedPolicyType(t *testing.T) {
+	t.Parallel()
+
+	policy := standardPolicy(dailyScheduleConfig(1, 0))
+	policy.BackupPlan.BackupPolicyType = externalEonSdkAPI.BACKUP_POLICY_TYPE_AWS_NATIVE_STANDARD
+
+	data := BackupPolicyResourceModel{}
+	diags := flattenBackupPolicy(context.Background(), policy, policySchemaType(t), &data)
+	require.True(t, diags.HasError(), "AWS_NATIVE_STANDARD should be rejected")
+	assert.Contains(t, diags.Errors()[0].Detail(), "AWS_NATIVE_STANDARD")
+}
+
+// TestFlattenIntervalConfig_KeepsConfiguredUnit pins the ambiguity that makes a naive refresh diff
+// forever: the API stores a standard interval in hours, so a configuration written in minutes must
+// come back in minutes.
+func TestFlattenIntervalConfig_KeepsConfiguredUnit(t *testing.T) {
+	t.Parallel()
+
+	schemaType := policySchemaType(t)
+	standardPlanType, diags := nestedObjectType(schemaType, "backup_plan")
+	require.False(t, diags.HasError())
+	standardPlanType, diags = nestedObjectType(standardPlanType, "standard_plan")
+	require.False(t, diags.HasError())
+	scheduleType, diags := nestedListElementType(standardPlanType, "backup_schedules")
+	require.False(t, diags.HasError())
+	configType, diags := nestedObjectType(scheduleType, "schedule_config")
+	require.False(t, diags.HasError())
+	intervalType, diags := nestedObjectType(configType, "interval_config")
+	require.False(t, diags.HasError())
+
+	priorWith := func(attrs map[string]attr.Value) types.Object {
+		object, objectDiags := objectValue(intervalType, attrs)
+		require.False(t, objectDiags.HasError())
+		return object
+	}
+
+	tests := []struct {
+		name            string
+		prior           types.Object
+		expectedMinutes types.Int64
+		expectedHours   types.Int64
+		expectedWindow  types.Int64
+	}{
+		{
+			name:            "configuration used minutes",
+			prior:           priorWith(map[string]attr.Value{"interval_minutes": types.Int64Value(720)}),
+			expectedMinutes: types.Int64Value(720),
+			expectedHours:   types.Int64Null(),
+			expectedWindow:  types.Int64Null(),
+		},
+		{
+			name:            "configuration used hours",
+			prior:           priorWith(map[string]attr.Value{"interval_hours": types.Int64Value(12)}),
+			expectedMinutes: types.Int64Null(),
+			expectedHours:   types.Int64Value(12),
+			expectedWindow:  types.Int64Null(),
+		},
+		{
+			name: "start window has no API field and is carried over",
+			prior: priorWith(map[string]attr.Value{
+				"interval_hours":       types.Int64Value(12),
+				"start_window_minutes": types.Int64Value(45),
+			}),
+			expectedMinutes: types.Int64Null(),
+			expectedHours:   types.Int64Value(12),
+			expectedWindow:  types.Int64Value(45),
+		},
+		{
+			name:            "no prior state falls back to hours",
+			prior:           types.ObjectNull(intervalType.AttrTypes),
+			expectedMinutes: types.Int64Null(),
+			expectedHours:   types.Int64Value(12),
+			expectedWindow:  types.Int64Null(),
+		},
+		{
+			name:            "prior no longer matches the API interval",
+			prior:           priorWith(map[string]attr.Value{"interval_hours": types.Int64Value(6)}),
+			expectedMinutes: types.Int64Null(),
+			expectedHours:   types.Int64Value(12),
+			expectedWindow:  types.Int64Null(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			flattened, flattenDiags := flattenIntervalConfig(intervalType, 720, tt.prior)
+			require.False(t, flattenDiags.HasError(), "unexpected diagnostics: %v", flattenDiags.Errors())
+
+			assert.Equal(t, tt.expectedMinutes, flattened.Attributes()["interval_minutes"])
+			assert.Equal(t, tt.expectedHours, flattened.Attributes()["interval_hours"])
+			assert.Equal(t, tt.expectedWindow, flattened.Attributes()["start_window_minutes"])
+		})
+	}
+}
+
+func TestFlattenScheduleTimezone(t *testing.T) {
+	t.Parallel()
+
+	utc := externalEonSdkAPI.SCHEDULE_TIMEZONE_UTC
+	resourceLocal := externalEonSdkAPI.SCHEDULE_TIMEZONE_RESOURCE
+
+	tests := []struct {
+		name     string
+		timezone *externalEonSdkAPI.ScheduleTimezone
+		prior    types.String
+		expected types.String
+	}{
+		{
+			name:     "API default stays unset when the configuration omitted it",
+			timezone: &utc,
+			prior:    types.StringNull(),
+			expected: types.StringNull(),
+		},
+		{
+			name:     "explicit UTC is kept",
+			timezone: &utc,
+			prior:    types.StringValue("UTC"),
+			expected: types.StringValue("UTC"),
+		},
+		{
+			name:     "drift away from the default is reported",
+			timezone: &resourceLocal,
+			prior:    types.StringNull(),
+			expected: types.StringValue("RESOURCE"),
+		},
+		{
+			name:     "absent timezone is null",
+			timezone: nil,
+			prior:    types.StringValue("UTC"),
+			expected: types.StringNull(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, flattenScheduleTimezone(tt.timezone, tt.prior))
+		})
+	}
+}
+
+// TestFlattenBackupPolicy_MonthlyAndAnnually covers the two schedule kinds whose day and month were
+// never sent to the API, so a refresh had nothing to compare against.
+func TestFlattenBackupPolicy_MonthlyAndAnnually(t *testing.T) {
+	t.Parallel()
+
+	monthlyConfig := externalEonSdkAPI.NewMonthlyConfig()
+	monthlyConfig.SetTimeOfDay(*externalEonSdkAPI.NewTimeOfDay(2, 30))
+	monthlyConfig.SetDaysOfMonth([]int32{14})
+	monthly := externalEonSdkAPI.NewStandardBackupScheduleConfig(externalEonSdkAPI.STANDARD_BACKUP_SCHEDULE_MONTHLY)
+	monthly.SetMonthlyConfig(*monthlyConfig)
+
+	annuallyConfig := externalEonSdkAPI.NewAnnuallyConfig()
+	annuallyConfig.SetTimeOfDay(*externalEonSdkAPI.NewTimeOfDay(4, 0))
+	annuallyConfig.SetTimeOfYear(*externalEonSdkAPI.NewTimeOfYear(9, 21))
+	annually := externalEonSdkAPI.NewStandardBackupScheduleConfig(externalEonSdkAPI.STANDARD_BACKUP_SCHEDULE_ANNUALLY)
+	annually.SetAnnuallyConfig(*annuallyConfig)
+
+	schemaType := policySchemaType(t)
+
+	monthlyData := BackupPolicyResourceModel{}
+	diags := flattenBackupPolicy(context.Background(), standardPolicy(*monthly), schemaType, &monthlyData)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags.Errors())
+	assert.Equal(t, types.Int64Value(14),
+		nestedValue(t, monthlyData.BackupPlan, "standard_plan", "backup_schedules", "schedule_config", "monthly_config", "day_of_month"))
+
+	annuallyData := BackupPolicyResourceModel{}
+	diags = flattenBackupPolicy(context.Background(), standardPolicy(*annually), schemaType, &annuallyData)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags.Errors())
+	assert.Equal(t, types.StringValue("SEPTEMBER"),
+		nestedValue(t, annuallyData.BackupPlan, "standard_plan", "backup_schedules", "schedule_config", "annually_config", "month"))
+	assert.Equal(t, types.Int64Value(21),
+		nestedValue(t, annuallyData.BackupPlan, "standard_plan", "backup_schedules", "schedule_config", "annually_config", "day_of_month"))
+}
+
+func TestFlattenBackupPolicy_HighFrequencyPlan(t *testing.T) {
+	t.Parallel()
+
+	intervalConfig := externalEonSdkAPI.NewHighFrequencyIntervalConfig(15)
+	scheduleConfig := externalEonSdkAPI.NewHighFrequencyBackupScheduleConfig()
+	scheduleConfig.SetFrequency(externalEonSdkAPI.HIGH_FREQUENCY_BACKUP_SCHEDULE_INTERVAL)
+	scheduleConfig.SetIntervalConfig(*intervalConfig)
+
+	resourceType := externalEonSdkAPI.NewHighFrequencyBackupResourceType()
+	resourceType.SetResourceType(externalEonSdkAPI.ResourceType("AWS_EBS"))
+
+	schedule := externalEonSdkAPI.NewHighFrequencyBackupSchedules("vault-hf", *scheduleConfig, 7)
+	highFrequencyPlan := externalEonSdkAPI.NewHighFrequencyBackupPolicyPlan(
+		[]externalEonSdkAPI.HighFrequencyBackupResourceType{*resourceType},
+		[]externalEonSdkAPI.HighFrequencyBackupSchedules{*schedule},
+	)
+
+	plan := externalEonSdkAPI.NewBackupPolicyPlan(externalEonSdkAPI.BACKUP_POLICY_TYPE_HIGH_FREQUENCY)
+	plan.SetHighFrequencyPlan(*highFrequencyPlan)
+
+	selector := externalEonSdkAPI.NewBackupPolicyResourceSelector(externalEonSdkAPI.RESOURCE_SELECTOR_MODE_ALL)
+	policy := externalEonSdkAPI.NewBackupPolicy("policy-hf", "every-15", true, *selector, *plan)
+
+	data := BackupPolicyResourceModel{}
+	diags := flattenBackupPolicy(context.Background(), policy, policySchemaType(t), &data)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags.Errors())
+
+	assert.Equal(t, types.Int64Value(15),
+		nestedValue(t, data.BackupPlan, "high_frequency_plan", "backup_schedules", "schedule_config", "interval_config", "interval_minutes"))
+
+	resourceTypes, ok := nestedValue(t, data.BackupPlan, "high_frequency_plan", "resource_types").(types.List)
+	require.True(t, ok)
+	assert.Equal(t, []attr.Value{types.StringValue("AWS_EBS")}, resourceTypes.Elements())
+}
+
+func TestMonthNameAndNumberRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for month := int32(1); month <= 12; month++ {
+		name, err := monthName(month)
+		require.NoError(t, err)
+
+		number, err := monthNumber(name)
+		require.NoError(t, err)
+		assert.Equal(t, month, number, "%s should map back to %d", name, month)
+	}
+
+	_, err := monthName(0)
+	assert.Error(t, err)
+	_, err = monthName(13)
+	assert.Error(t, err)
+	_, err = monthNumber("SMARCH")
+	assert.Error(t, err)
+}
+
+// TestObjectAttributes_RejectsNullObject pins the crash the customer hit: a null object answers
+// Attributes() with an empty map, and the old code asserted the concrete type of the resulting nil.
+func TestObjectAttributes_RejectsNullObject(t *testing.T) {
+	t.Parallel()
+
+	attrs, err := objectAttributes(types.ObjectNull(map[string]attr.Type{"resource_selection_mode": types.StringType}), "resource_selector")
+	require.Error(t, err, "a null object must be reported, not indexed")
+	assert.Nil(t, attrs)
+	assert.Contains(t, err.Error(), "ignore_changes")
+
+	populated, objectDiags := types.ObjectValue(
+		map[string]attr.Type{"resource_selection_mode": types.StringType},
+		map[string]attr.Value{"resource_selection_mode": types.StringValue("ALL")},
+	)
+	require.False(t, objectDiags.HasError())
+
+	attrs, objectErr := objectAttributes(populated, "resource_selector")
+	require.NoError(t, objectErr)
+
+	mode, modeErr := stringAttr(attrs, "resource_selector", "resource_selection_mode")
+	require.NoError(t, modeErr)
+	assert.Equal(t, "ALL", mode.ValueString())
+
+	_, missingErr := stringAttr(attrs, "resource_selector", "nope")
+	assert.Error(t, missingErr)
+}

--- a/internal/provider/resource_backup_policy.go
+++ b/internal/provider/resource_backup_policy.go
@@ -803,11 +803,11 @@ func (r *BackupPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 				},
 			},
 			"created_at": schema.StringAttribute{
-				MarkdownDescription: "Creation timestamp",
+				MarkdownDescription: "Time at which Terraform created this policy. Eon does not report policy timestamps, so this records the local apply time and is not refreshed afterwards",
 				Computed:            true,
 			},
 			"updated_at": schema.StringAttribute{
-				MarkdownDescription: "Last update timestamp",
+				MarkdownDescription: "Time at which Terraform last applied a change to this policy. Eon does not report policy timestamps, so this records the local apply time and is not refreshed afterwards",
 				Computed:            true,
 			},
 		},
@@ -836,8 +836,17 @@ func (r *BackupPolicyResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	resourceSelectorAttrs := data.ResourceSelector.Attributes()
-	resourceSelectionMode := resourceSelectorAttrs["resource_selection_mode"].(types.String)
+	resourceSelectorAttrs, err := objectAttributes(data.ResourceSelector, "resource_selector")
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Resource Selector", err.Error())
+		return
+	}
+
+	resourceSelectionMode, err := stringAttr(resourceSelectorAttrs, "resource_selector", "resource_selection_mode")
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Resource Selector", err.Error())
+		return
+	}
 
 	resourceSelector := externalEonSdkAPI.NewBackupPolicyResourceSelector(
 		externalEonSdkAPI.ResourceSelectorMode(resourceSelectionMode.ValueString()),
@@ -878,8 +887,17 @@ func (r *BackupPolicyResource) Create(ctx context.Context, req resource.CreateRe
 		resourceSelector.SetResourceExclusionOverride(exclusionOverride)
 	}
 
-	backupPlanAttrs := data.BackupPlan.Attributes()
-	backupPolicyType := backupPlanAttrs["backup_policy_type"].(types.String)
+	backupPlanAttrs, err := objectAttributes(data.BackupPlan, "backup_plan")
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Backup Plan", err.Error())
+		return
+	}
+
+	backupPolicyType, err := stringAttr(backupPlanAttrs, "backup_plan", "backup_policy_type")
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Backup Plan", err.Error())
+		return
+	}
 
 	backupPlan := externalEonSdkAPI.NewBackupPolicyPlan(
 		externalEonSdkAPI.BackupPolicyType(backupPolicyType.ValueString()),
@@ -888,7 +906,11 @@ func (r *BackupPolicyResource) Create(ctx context.Context, req resource.CreateRe
 	var diags diag.Diagnostics
 	switch backupPolicyType.ValueString() {
 	case "STANDARD", "PITR":
-		standardPlanObj := backupPlanAttrs["standard_plan"].(types.Object)
+		standardPlanObj, err := requiredPlanObject(backupPlanAttrs, "standard_plan", backupPolicyType.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Missing Standard Plan", err.Error())
+			return
+		}
 		var standardPlanModel StandardPlanModel
 		diags = standardPlanObj.As(ctx, &standardPlanModel, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
@@ -936,7 +958,11 @@ func (r *BackupPolicyResource) Create(ctx context.Context, req resource.CreateRe
 		backupPlan.SetStandardPlan(*standardPlan)
 
 	case "HIGH_FREQUENCY":
-		highFrequencyPlanObj := backupPlanAttrs["high_frequency_plan"].(types.Object)
+		highFrequencyPlanObj, err := requiredPlanObject(backupPlanAttrs, "high_frequency_plan", backupPolicyType.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Missing High Frequency Plan", err.Error())
+			return
+		}
 		var highFrequencyPlanModel HighFrequencyPlanModel
 		diags = highFrequencyPlanObj.As(ctx, &highFrequencyPlanModel, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
@@ -1121,8 +1147,17 @@ func (r *BackupPolicyResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	resourceSelectorAttrs := plan.ResourceSelector.Attributes()
-	resourceSelectionMode := resourceSelectorAttrs["resource_selection_mode"].(types.String)
+	resourceSelectorAttrs, err := objectAttributes(plan.ResourceSelector, "resource_selector")
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Resource Selector", err.Error())
+		return
+	}
+
+	resourceSelectionMode, err := stringAttr(resourceSelectorAttrs, "resource_selector", "resource_selection_mode")
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Resource Selector", err.Error())
+		return
+	}
 
 	resourceSelector := externalEonSdkAPI.NewBackupPolicyResourceSelector(
 		externalEonSdkAPI.ResourceSelectorMode(resourceSelectionMode.ValueString()),
@@ -1163,8 +1198,17 @@ func (r *BackupPolicyResource) Update(ctx context.Context, req resource.UpdateRe
 		resourceSelector.SetResourceExclusionOverride(exclusionOverride)
 	}
 
-	backupPlanAttrs := plan.BackupPlan.Attributes()
-	backupPolicyType := backupPlanAttrs["backup_policy_type"].(types.String)
+	backupPlanAttrs, err := objectAttributes(plan.BackupPlan, "backup_plan")
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Backup Plan", err.Error())
+		return
+	}
+
+	backupPolicyType, err := stringAttr(backupPlanAttrs, "backup_plan", "backup_policy_type")
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Backup Plan", err.Error())
+		return
+	}
 
 	backupPlan := externalEonSdkAPI.NewBackupPolicyPlan(
 		externalEonSdkAPI.BackupPolicyType(backupPolicyType.ValueString()),
@@ -1172,7 +1216,11 @@ func (r *BackupPolicyResource) Update(ctx context.Context, req resource.UpdateRe
 
 	switch backupPolicyType.ValueString() {
 	case "STANDARD", "PITR":
-		standardPlanObj := backupPlanAttrs["standard_plan"].(types.Object)
+		standardPlanObj, err := requiredPlanObject(backupPlanAttrs, "standard_plan", backupPolicyType.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Missing Standard Plan", err.Error())
+			return
+		}
 		var standardPlanModel StandardPlanModel
 		diags := standardPlanObj.As(ctx, &standardPlanModel, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
@@ -1220,7 +1268,11 @@ func (r *BackupPolicyResource) Update(ctx context.Context, req resource.UpdateRe
 		backupPlan.SetStandardPlan(*standardPlan)
 
 	case "HIGH_FREQUENCY":
-		highFrequencyPlanObj := backupPlanAttrs["high_frequency_plan"].(types.Object)
+		highFrequencyPlanObj, err := requiredPlanObject(backupPlanAttrs, "high_frequency_plan", backupPolicyType.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Missing High Frequency Plan", err.Error())
+			return
+		}
 		var highFrequencyPlanModel HighFrequencyPlanModel
 		diags := highFrequencyPlanObj.As(ctx, &highFrequencyPlanModel, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
@@ -1352,7 +1404,10 @@ func (r *BackupPolicyResource) Update(ctx context.Context, req resource.UpdateRe
 	plan.Id = types.StringValue(updatedPolicy.Id)
 	plan.Name = types.StringValue(updatedPolicy.Name)
 	plan.Enabled = types.BoolValue(updatedPolicy.Enabled)
-	plan.CreatedAt = types.StringValue(time.Now().Format(time.RFC3339))
+	plan.CreatedAt = state.CreatedAt
+	if plan.CreatedAt.IsNull() || plan.CreatedAt.IsUnknown() {
+		plan.CreatedAt = types.StringValue(time.Now().Format(time.RFC3339))
+	}
 	plan.UpdatedAt = types.StringValue(time.Now().Format(time.RFC3339))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/internal/provider/resource_backup_policy.go
+++ b/internal/provider/resource_backup_policy.go
@@ -1124,13 +1124,28 @@ func (r *BackupPolicyResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	data.Id = types.StringValue(policy.Id)
-	data.Name = types.StringValue(policy.Name)
-	data.Enabled = types.BoolValue(policy.Enabled)
-	data.CreatedAt = types.StringValue(time.Now().Format(time.RFC3339))
-	data.UpdatedAt = types.StringValue(time.Now().Format(time.RFC3339))
+	schemaType, ok := r.schemaObjectType(ctx)
+	if !ok {
+		resp.Diagnostics.AddError("Backup Policy Refresh Failed", "The backup policy schema is not an object type")
+		return
+	}
+
+	resp.Diagnostics.Append(flattenBackupPolicy(ctx, policy, schemaType, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// schemaObjectType exposes the resource schema as an object type so the refresh path can read the
+// shape of each nested attribute from the schema rather than restating it.
+func (r *BackupPolicyResource) schemaObjectType(ctx context.Context) (types.ObjectType, bool) {
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+
+	objectType, ok := schemaResp.Schema.Type().(types.ObjectType)
+	return objectType, ok
 }
 
 func (r *BackupPolicyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -1587,10 +1602,10 @@ func createStandardScheduleConfig(schedule *BackupScheduleModel) (*externalEonSd
 		if monthlyConfigObj, exists := scheduleConfigAttrs["monthly_config"]; exists && !monthlyConfigObj.IsNull() {
 			monthlyConfigAttrs := monthlyConfigObj.(types.Object).Attributes()
 
-			// dayOfMonth, err := SafeInt32Conversion(monthlyConfigAttrs["day_of_month"].(types.Int64).ValueInt64())
-			// if err != nil {
-			//	return nil, fmt.Errorf("invalid day of month: %s", err)
-			// }
+			dayOfMonth, err := SafeInt32Conversion(monthlyConfigAttrs["day_of_month"].(types.Int64).ValueInt64())
+			if err != nil {
+				return nil, fmt.Errorf("invalid day of month: %s", err)
+			}
 
 			timeOfDayHour, err := SafeInt32Conversion(monthlyConfigAttrs["time_of_day_hour"].(types.Int64).ValueInt64())
 			if err != nil {
@@ -1608,7 +1623,7 @@ func createStandardScheduleConfig(schedule *BackupScheduleModel) (*externalEonSd
 
 			monthlyConfig := externalEonSdkAPI.NewMonthlyConfig()
 			monthlyConfig.SetTimeOfDay(*timeOfDay)
-			// Note: DayOfMonth might need to be set differently based on SDK implementation
+			monthlyConfig.SetDaysOfMonth([]int32{dayOfMonth})
 
 			if startWindowObj, exists := monthlyConfigAttrs["start_window_minutes"]; exists && !startWindowObj.IsNull() {
 				startWindow, err := SafeInt32Conversion(startWindowObj.(types.Int64).ValueInt64())
@@ -1629,10 +1644,15 @@ func createStandardScheduleConfig(schedule *BackupScheduleModel) (*externalEonSd
 		if annuallyConfigObj, exists := scheduleConfigAttrs["annually_config"]; exists && !annuallyConfigObj.IsNull() {
 			annuallyConfigAttrs := annuallyConfigObj.(types.Object).Attributes()
 
-			// dayOfMonth, err := SafeInt32Conversion(annuallyConfigAttrs["day_of_month"].(types.Int64).ValueInt64())
-			// if err != nil {
-			//	return nil, fmt.Errorf("invalid day of month: %s", err)
-			// }
+			dayOfMonth, err := SafeInt32Conversion(annuallyConfigAttrs["day_of_month"].(types.Int64).ValueInt64())
+			if err != nil {
+				return nil, fmt.Errorf("invalid day of month: %s", err)
+			}
+
+			month, err := monthNumber(annuallyConfigAttrs["month"].(types.String).ValueString())
+			if err != nil {
+				return nil, fmt.Errorf("invalid month: %s", err)
+			}
 
 			timeOfDayHour, err := SafeInt32Conversion(annuallyConfigAttrs["time_of_day_hour"].(types.Int64).ValueInt64())
 			if err != nil {
@@ -1650,7 +1670,7 @@ func createStandardScheduleConfig(schedule *BackupScheduleModel) (*externalEonSd
 
 			annuallyConfig := externalEonSdkAPI.NewAnnuallyConfig()
 			annuallyConfig.SetTimeOfDay(*timeOfDay)
-			// Note: Month and DayOfMonth might need to be set differently based on SDK implementation
+			annuallyConfig.SetTimeOfYear(*externalEonSdkAPI.NewTimeOfYear(month, dayOfMonth))
 
 			if startWindowObj, exists := annuallyConfigAttrs["start_window_minutes"]; exists && !startWindowObj.IsNull() {
 				startWindow, err := SafeInt32Conversion(startWindowObj.(types.Int64).ValueInt64())

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -3,6 +3,9 @@ package provider
 import (
 	"fmt"
 	"math"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // SafeInt32Conversion performs bounds checking for int64 to int32 conversion
@@ -11,4 +14,66 @@ func SafeInt32Conversion(value int64) (int32, error) {
 		return 0, fmt.Errorf("value %d out of int32 bounds", value)
 	}
 	return int32(value), nil
+}
+
+// objectAttributes returns obj's attributes, refusing a null or unknown object. A null
+// types.Object still answers Attributes() with an empty map, so callers that index the result and
+// assert the element's concrete type crash the provider on a nil attr.Value instead of reporting
+// something a practitioner can act on. Terraform hands a null object whenever the attribute is
+// absent from the plan, which lifecycle.ignore_changes on that attribute is enough to cause.
+func objectAttributes(obj types.Object, path string) (map[string]attr.Value, error) {
+	if obj.IsNull() || obj.IsUnknown() {
+		return nil, fmt.Errorf(
+			"%s has no value in the plan. This happens when the attribute is excluded from the plan "+
+				"(for example by lifecycle.ignore_changes) while other attributes change, or when it was "+
+				"never written to state by an import. Set %s explicitly, or drop it from ignore_changes",
+			path, path)
+	}
+	return obj.Attributes(), nil
+}
+
+func attrValue(attrs map[string]attr.Value, parent, name string) (attr.Value, error) {
+	value, ok := attrs[name]
+	if !ok || value == nil {
+		return nil, fmt.Errorf("%s.%s is missing from the plan", parent, name)
+	}
+	return value, nil
+}
+
+func stringAttr(attrs map[string]attr.Value, parent, name string) (types.String, error) {
+	value, err := attrValue(attrs, parent, name)
+	if err != nil {
+		return types.StringNull(), err
+	}
+	typed, ok := value.(types.String)
+	if !ok {
+		return types.StringNull(), fmt.Errorf("%s.%s is %T, expected a string", parent, name, value)
+	}
+	return typed, nil
+}
+
+// requiredPlanObject fetches the plan variant that backupPolicyType selects, rejecting the null
+// object Terraform supplies for the other, unconfigured variants.
+func requiredPlanObject(backupPlanAttrs map[string]attr.Value, name, backupPolicyType string) (types.Object, error) {
+	planObj, err := objectAttr(backupPlanAttrs, "backup_plan", name)
+	if err != nil {
+		return types.ObjectNull(nil), err
+	}
+	if planObj.IsNull() || planObj.IsUnknown() {
+		return types.ObjectNull(nil), fmt.Errorf(
+			"backup_plan.%s is required when backup_policy_type is '%s'", name, backupPolicyType)
+	}
+	return planObj, nil
+}
+
+func objectAttr(attrs map[string]attr.Value, parent, name string) (types.Object, error) {
+	value, err := attrValue(attrs, parent, name)
+	if err != nil {
+		return types.ObjectNull(nil), err
+	}
+	typed, ok := value.(types.Object)
+	if !ok {
+		return types.ObjectNull(nil), fmt.Errorf("%s.%s is %T, expected an object", parent, name, value)
+	}
+	return typed, nil
 }


### PR DESCRIPTION
Fixes the `eon_backup_policy` drift, import and crash behaviour a customer reported against provider v2.0.22 (feedback relayed on EON-16210).

## Problem

- **Drift was invisible.** `Read` only set `id`, `name` and `enabled`, carrying `resource_selector` and `backup_plan` over from prior state. Editing a policy's selector or schedule in the Eon console left `terraform plan` reporting "No changes".
- **Import produced phantom diffs.** With nothing written to state, both attributes appeared as `+` additions on every plan instead of comparing against the live policy.
- **`created_at` / `updated_at` diffed on every plan.** Neither exists in the Eon API; Create and Read both stamped `time.Now()`.
- **The provider panicked** with `interface conversion: attr.Value is nil, not basetypes.StringValue` when `resource_selector` was absent from the plan — reproducible via `ignore_changes = [resource_selector]` after an import.

Together these meant a plan diff did not predict what an apply would change. The customer lost a production selector that way.

## Changes

**Panic guards.** A null `types.Object` answers `Attributes()` with an empty map, so indexing it and asserting the element type crashed on a nil `attr.Value`. Every lookup on `resource_selector`, `backup_plan`, `standard_plan` and `high_frequency_plan` in Create and Update now reports which attribute is missing and why.

**Timestamps.** No longer overwritten on read; `created_at` carries through Update rather than being reset. Both are documented as Terraform-local values, since Eon reports no policy timestamps.

**Refresh.** New `backup_policy_flatten.go` maps the API response back into `resource_selector` and `backup_plan` — selection mode, overrides, the five top-level expression conditions, group conditions with all fourteen operand conditions, and all three plan variants across their five schedule frequencies. Nested attribute shapes are read off the resource schema, so the mapper cannot drift away from the schema it must satisfy.

Representations the API cannot round-trip are resolved against prior state rather than rewritten, because rewriting them would diff on every plan:

| Ambiguity | Resolution |
|---|---|
| `interval_minutes` vs `interval_hours` | same interval — the configured unit is kept |
| `start_window_minutes` on interval schedules | no API field exists; prior value carried |
| omitted `schedule_timezone` | stays null when Eon reports its UTC default |
| explicit empty override list | kept empty rather than flipped to null |

Conditions and plan types the schema cannot express (`AWS_NATIVE_STANDARD`, top-level `resource_name`, multi-day weekly/monthly, `source_account_tag_keys`) raise a named error instead of being silently dropped — a state no configuration can reproduce reads as an undiffable plan forever.

**Forward-mapper gap this exposed.** `monthly_config.day_of_month` and `annually_config.month` / `day_of_month` were accepted by the schema but never sent to the API, so a refresh had nothing to compare against. Now sent.

## Testing

`go build`, `go vet`, `go test ./...` and `golangci-lint` all clean. Ten new tests cover selector and plan refresh, group expressions, both rejection paths, the interval-unit and timezone reconciliation tables, monthly/annual schedules, high-frequency plans, month mapping, and the null-object guard.

Unit level only — no acceptance run against a live Eon API, so the end-to-end "console edit appears in `terraform plan`" behaviour is verified by construction rather than by a real apply.

## Known limits

- A policy using an unrepresentable condition or plan type now errors on refresh instead of under-reporting. Clearer, but it blocks plan for such a policy until the provider covers it.
- `interval` schedules still cannot send `start_window_minutes`; no such field exists on `StandardIntervalConfig` / `HighFrequencyIntervalConfig` in eon-sdk-go v1.173.0.
- After import, `created_at` / `updated_at` stay null until the next apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)