### PR TITLE
feat(backup-policy): expose AWS source-account backup destination on eon_backup_policy (EON-16278)

### DIFF
--- a/docs/data-sources/backup_policies.md
+++ b/docs/data-sources/backup_policies.md
@@ -75,7 +75,7 @@ resource "local_file" "backup_policy_report" {
 
 Read-Only:
 
-- `backup_policy_type` (String) The type of the policy. Possible values: `UNSPECIFIED`, `STANDARD`, `HIGH_FREQUENCY`, `PITR`, `AWS_NATIVE_PITR`.
+- `backup_policy_type` (String) The type of the policy. Possible values: `UNSPECIFIED`, `STANDARD`, `HIGH_FREQUENCY`, `PITR`, `AWS_NATIVE_PITR`, `AWS_NATIVE_STANDARD`.
 - `enabled` (Boolean) Whether the backup policy is enabled.
 - `id` (String) Backup policy ID.
 - `name` (String) Backup policy display name.

--- a/docs/resources/backup_policy.md
+++ b/docs/resources/backup_policy.md
@@ -244,6 +244,60 @@ resource "eon_backup_policy" "aws_native_pitr_backup" {
   }
 }
 
+# Example: AWS source-account backups, the only destination available for EFS and FSx
+resource "eon_backup_policy" "aws_native_standard_backup" {
+  name    = "EFS Production - Source Account Backups"
+  enabled = true
+  resource_selector = {
+    resource_selection_mode = "CONDITIONAL"
+
+    expression = {
+      group = {
+        operator = "AND"
+        operands = [
+          {
+            resource_type = {
+              operator       = "IN"
+              resource_types = ["AWS_EFS"]
+            }
+          }
+        ]
+      }
+    }
+  }
+
+  backup_plan = {
+    backup_policy_type = "AWS_NATIVE_STANDARD"
+
+    aws_native_standard_plan = {
+      backup_schedules = [
+        {
+          # Omit target_region to keep each backup in its resource's own region.
+          target_region  = "us-east-1"
+          retention_days = 30
+          schedule_config = {
+            frequency = "DAILY"
+            daily_config = {
+              time_of_day_hour     = 2
+              time_of_day_minutes  = 0
+              start_window_minutes = 240
+            }
+          }
+        },
+        {
+          retention_days = 7
+          schedule_config = {
+            frequency = "INTERVAL"
+            interval_config = {
+              interval_hours = 4
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
 # Example: Conditional backup policy using new condition types
 resource "eon_backup_policy" "conditional_backup" {
   name    = "Conditional Production Backup"
@@ -562,11 +616,12 @@ output "backup_policies_summary" {
 
 Required:
 
-- `backup_policy_type` (String) Backup policy type: 'STANDARD', 'HIGH_FREQUENCY', 'PITR', or 'AWS_NATIVE_PITR'
+- `backup_policy_type` (String) Backup policy type: 'STANDARD', 'HIGH_FREQUENCY', 'PITR', 'AWS_NATIVE_PITR', or 'AWS_NATIVE_STANDARD'
 
 Optional:
 
 - `aws_native_pitr_plan` (Attributes) AWS native PITR (Point-in-Time Recovery) backup plan for RDS/Aurora continuous backups (see [below for nested schema](#nestedatt--backup_plan--aws_native_pitr_plan))
+- `aws_native_standard_plan` (Attributes) AWS native standard backup plan, storing snapshots in the AWS source account instead of an Eon vault (mirrors the console's "Store snapshots in: AWS source account" destination). Required when backup_policy_type is 'AWS_NATIVE_STANDARD', which is the only way to back up EFS and FSx, whose native backups cannot leave the source account (see [below for nested schema](#nestedatt--backup_plan--aws_native_standard_plan))
 - `high_frequency_plan` (Attributes) High frequency backup plan configuration (see [below for nested schema](#nestedatt--backup_plan--high_frequency_plan))
 - `standard_plan` (Attributes) Standard backup plan configuration (see [below for nested schema](#nestedatt--backup_plan--standard_plan))
 
@@ -577,6 +632,106 @@ Required:
 
 - `resource_type` (String) Resource type for PITR backup, e.g. 'AWS_RDS'
 - `retention_days` (Number) Number of days to retain continuous backups using AWS Backup. AWS allows 1-35 days for RDS/Aurora continuous backups
+
+
+<a id="nestedatt--backup_plan--aws_native_standard_plan"></a>
+### Nested Schema for `backup_plan.aws_native_standard_plan`
+
+Required:
+
+- `backup_schedules` (Attributes List) List of backup schedules (see [below for nested schema](#nestedatt--backup_plan--aws_native_standard_plan--backup_schedules))
+
+<a id="nestedatt--backup_plan--aws_native_standard_plan--backup_schedules"></a>
+### Nested Schema for `backup_plan.aws_native_standard_plan.backup_schedules`
+
+Required:
+
+- `retention_days` (Number) Retention days. Minimum 1 for DAILY and INTERVAL, 14 for WEEKLY, 60 for MONTHLY, 730 for ANNUALLY; maximum 36500, the AWS Backup ceiling
+- `schedule_config` (Attributes) Schedule configuration (see [below for nested schema](#nestedatt--backup_plan--aws_native_standard_plan--backup_schedules--schedule_config))
+
+Optional:
+
+- `target_region` (String) AWS region the backups are copied to, e.g. 'us-east-1'. Omit to keep each backup in its resource's own region
+
+<a id="nestedatt--backup_plan--aws_native_standard_plan--backup_schedules--schedule_config"></a>
+### Nested Schema for `backup_plan.aws_native_standard_plan.backup_schedules.schedule_config`
+
+Required:
+
+- `frequency` (String) Frequency: 'DAILY', 'WEEKLY', 'MONTHLY', 'ANNUALLY', 'INTERVAL'
+
+Optional:
+
+- `annually_config` (Attributes) Annually configuration (see [below for nested schema](#nestedatt--backup_plan--aws_native_standard_plan--backup_schedules--schedule_config--annually_config))
+- `daily_config` (Attributes) Daily configuration (see [below for nested schema](#nestedatt--backup_plan--aws_native_standard_plan--backup_schedules--schedule_config--daily_config))
+- `interval_config` (Attributes) Interval configuration. Specify either interval_minutes OR interval_hours (not both) (see [below for nested schema](#nestedatt--backup_plan--aws_native_standard_plan--backup_schedules--schedule_config--interval_config))
+- `monthly_config` (Attributes) Monthly configuration (see [below for nested schema](#nestedatt--backup_plan--aws_native_standard_plan--backup_schedules--schedule_config--monthly_config))
+- `weekly_config` (Attributes) Weekly configuration (see [below for nested schema](#nestedatt--backup_plan--aws_native_standard_plan--backup_schedules--schedule_config--weekly_config))
+
+<a id="nestedatt--backup_plan--aws_native_standard_plan--backup_schedules--schedule_config--annually_config"></a>
+### Nested Schema for `backup_plan.aws_native_standard_plan.backup_schedules.schedule_config.annually_config`
+
+Required:
+
+- `day_of_month` (Number) Day of month (1-31)
+- `month` (String) Month: 'JANUARY', 'FEBRUARY', 'MARCH', 'APRIL', 'MAY', 'JUNE', 'JULY', 'AUGUST', 'SEPTEMBER', 'OCTOBER', 'NOVEMBER', 'DECEMBER'
+
+Optional:
+
+- `start_window_minutes` (Number) Start window in minutes
+- `time_of_day_hour` (Number) Hour of day (0-23)
+- `time_of_day_minutes` (Number) Minutes of hour (0-59)
+
+
+<a id="nestedatt--backup_plan--aws_native_standard_plan--backup_schedules--schedule_config--daily_config"></a>
+### Nested Schema for `backup_plan.aws_native_standard_plan.backup_schedules.schedule_config.daily_config`
+
+Optional:
+
+- `start_window_minutes` (Number) Start window in minutes
+- `time_of_day_hour` (Number) Hour of day (0-23)
+- `time_of_day_minutes` (Number) Minutes of hour (0-59)
+
+
+<a id="nestedatt--backup_plan--aws_native_standard_plan--backup_schedules--schedule_config--interval_config"></a>
+### Nested Schema for `backup_plan.aws_native_standard_plan.backup_schedules.schedule_config.interval_config`
+
+Optional:
+
+- `interval_hours` (Number) Interval in hours. Either this or interval_minutes must be specified (not both)
+- `interval_minutes` (Number) Interval in minutes. Either this or interval_hours must be specified (not both). Must be divisible by 60
+- `start_window_minutes` (Number) Start window in minutes
+
+
+<a id="nestedatt--backup_plan--aws_native_standard_plan--backup_schedules--schedule_config--monthly_config"></a>
+### Nested Schema for `backup_plan.aws_native_standard_plan.backup_schedules.schedule_config.monthly_config`
+
+Required:
+
+- `day_of_month` (Number) Day of month (1-31)
+
+Optional:
+
+- `start_window_minutes` (Number) Start window in minutes
+- `time_of_day_hour` (Number) Hour of day (0-23)
+- `time_of_day_minutes` (Number) Minutes of hour (0-59)
+
+
+<a id="nestedatt--backup_plan--aws_native_standard_plan--backup_schedules--schedule_config--weekly_config"></a>
+### Nested Schema for `backup_plan.aws_native_standard_plan.backup_schedules.schedule_config.weekly_config`
+
+Required:
+
+- `day_of_week` (String) Day of week: 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'
+
+Optional:
+
+- `start_window_minutes` (Number) Start window in minutes
+- `time_of_day_hour` (Number) Hour of day (0-23)
+- `time_of_day_minutes` (Number) Minutes of hour (0-59)
+
+
+
 
 
 <a id="nestedatt--backup_plan--high_frequency_plan"></a>

--- a/examples/resources/eon_backup_policy/resource.tf
+++ b/examples/resources/eon_backup_policy/resource.tf
@@ -229,6 +229,60 @@ resource "eon_backup_policy" "aws_native_pitr_backup" {
   }
 }
 
+# Example: AWS source-account backups, the only destination available for EFS and FSx
+resource "eon_backup_policy" "aws_native_standard_backup" {
+  name    = "EFS Production - Source Account Backups"
+  enabled = true
+  resource_selector = {
+    resource_selection_mode = "CONDITIONAL"
+
+    expression = {
+      group = {
+        operator = "AND"
+        operands = [
+          {
+            resource_type = {
+              operator       = "IN"
+              resource_types = ["AWS_EFS"]
+            }
+          }
+        ]
+      }
+    }
+  }
+
+  backup_plan = {
+    backup_policy_type = "AWS_NATIVE_STANDARD"
+
+    aws_native_standard_plan = {
+      backup_schedules = [
+        {
+          # Omit target_region to keep each backup in its resource's own region.
+          target_region  = "us-east-1"
+          retention_days = 30
+          schedule_config = {
+            frequency = "DAILY"
+            daily_config = {
+              time_of_day_hour     = 2
+              time_of_day_minutes  = 0
+              start_window_minutes = 240
+            }
+          }
+        },
+        {
+          retention_days = 7
+          schedule_config = {
+            frequency = "INTERVAL"
+            interval_config = {
+              interval_hours = 4
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
 # Example: Conditional backup policy using new condition types
 resource "eon_backup_policy" "conditional_backup" {
   name    = "Conditional Production Backup"

--- a/internal/provider/backup_policy_flatten.go
+++ b/internal/provider/backup_policy_flatten.go
@@ -703,11 +703,29 @@ func flattenBackupPlan(
 		diags.Append(awsNativePitrDiags...)
 		present["aws_native_pitr_plan"] = flattened
 
+	case "AWS_NATIVE_STANDARD":
+		awsNativeStandard := plan.AwsNativeStandardPlan.Get()
+		if awsNativeStandard == nil {
+			diags.AddError("Backup Policy Refresh Failed", "Eon reported policy type AWS_NATIVE_STANDARD without an AWS native standard plan")
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+
+		awsNativeStandardType, typeDiags := nestedObjectType(t, "aws_native_standard_plan")
+		diags.Append(typeDiags...)
+		if diags.HasError() {
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+
+		flattened, awsNativeStandardDiags := flattenAwsNativeStandardPlan(
+			awsNativeStandardType, *awsNativeStandard, priorObject(prior, "aws_native_standard_plan"))
+		diags.Append(awsNativeStandardDiags...)
+		present["aws_native_standard_plan"] = flattened
+
 	default:
 		diags.AddError(
 			"Unsupported Backup Policy Type",
 			fmt.Sprintf("Eon reports this policy as type '%s', which this provider version cannot represent. "+
-				"Supported types: STANDARD, PITR, HIGH_FREQUENCY, AWS_NATIVE_PITR.", policyType),
+				"Supported types: %s.", policyType, supportedBackupPolicyTypes),
 		)
 		return types.ObjectNull(t.AttrTypes), diags
 	}
@@ -777,6 +795,95 @@ func flattenStandardPlan(
 	object, objectDiags := objectValue(t, present)
 	diags.Append(objectDiags...)
 	return object, diags
+}
+
+// flattenAwsNativeStandardPlan mirrors flattenStandardPlan for source-account schedules, which are
+// keyed by target region and carry no vault or plan-level timezone.
+func flattenAwsNativeStandardPlan(
+	t types.ObjectType,
+	plan externalEonSdkAPI.AwsNativeStandardBackupPolicyPlan,
+	prior types.Object,
+) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	scheduleType, typeDiags := nestedListElementType(t, "backup_schedules")
+	diags.Append(typeDiags...)
+	if diags.HasError() {
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	configType, typeDiags := nestedObjectType(scheduleType, "schedule_config")
+	diags.Append(typeDiags...)
+	if diags.HasError() {
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	schedules := make([]attr.Value, 0, len(plan.BackupSchedules))
+	for index, schedule := range plan.BackupSchedules {
+		priorSchedule := priorListElement(prior, "backup_schedules", index)
+
+		config, configDiags := flattenStandardScheduleConfig(
+			configType,
+			awsNativeStandardScheduleConfigAsStandard(schedule.ScheduleConfig),
+			priorObject(priorSchedule, "schedule_config"),
+		)
+		diags.Append(configDiags...)
+		if diags.HasError() {
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+
+		// An empty region means "back up in the resource's own region", which the configuration
+		// expresses by omitting target_region, so writing "" back would read as drift.
+		targetRegion := types.StringNull()
+		if schedule.TargetRegion != "" {
+			targetRegion = types.StringValue(schedule.TargetRegion)
+		}
+
+		flattened, scheduleDiags := objectValue(scheduleType, map[string]attr.Value{
+			"target_region":   targetRegion,
+			"retention_days":  types.Int64Value(int64(schedule.BackupRetentionDays)),
+			"schedule_config": config,
+		})
+		diags.Append(scheduleDiags...)
+		if diags.HasError() {
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+		schedules = append(schedules, flattened)
+	}
+
+	scheduleList, listDiags := types.ListValue(scheduleType, schedules)
+	diags.Append(listDiags...)
+	if diags.HasError() {
+		return types.ObjectNull(t.AttrTypes), diags
+	}
+
+	object, objectDiags := objectValue(t, map[string]attr.Value{"backup_schedules": scheduleList})
+	diags.Append(objectDiags...)
+	return object, diags
+}
+
+// awsNativeStandardScheduleConfigAsStandard re-keys the native schedule config onto its standard
+// twin, which shares every frequency config and differs only in the interval type.
+func awsNativeStandardScheduleConfigAsStandard(
+	config externalEonSdkAPI.AwsNativeStandardBackupScheduleConfig,
+) externalEonSdkAPI.StandardBackupScheduleConfig {
+	standard := externalEonSdkAPI.NewStandardBackupScheduleConfig(config.Frequency)
+	if interval := config.IntervalConfig.Get(); interval != nil {
+		standard.SetIntervalConfig(*externalEonSdkAPI.NewStandardIntervalConfig(interval.IntervalHours))
+	}
+	if daily := config.DailyConfig.Get(); daily != nil {
+		standard.SetDailyConfig(*daily)
+	}
+	if weekly := config.WeeklyConfig.Get(); weekly != nil {
+		standard.SetWeeklyConfig(*weekly)
+	}
+	if monthly := config.MonthlyConfig.Get(); monthly != nil {
+		standard.SetMonthlyConfig(*monthly)
+	}
+	if annually := config.AnnuallyConfig.Get(); annually != nil {
+		standard.SetAnnuallyConfig(*annually)
+	}
+	return *standard
 }
 
 // flattenScheduleTimezone keeps schedule_timezone null when the configuration omitted it and Eon

--- a/internal/provider/backup_policy_flatten_test.go
+++ b/internal/provider/backup_policy_flatten_test.go
@@ -145,12 +145,90 @@ func TestFlattenBackupPolicy_RejectsUnsupportedPolicyType(t *testing.T) {
 	t.Parallel()
 
 	policy := standardPolicy(dailyScheduleConfig(1, 0))
-	policy.BackupPlan.BackupPolicyType = externalEonSdkAPI.BACKUP_POLICY_TYPE_AWS_NATIVE_STANDARD
+	policy.BackupPlan.BackupPolicyType = externalEonSdkAPI.BACKUP_POLICY_TYPE_AZURE_FILES
 
 	data := BackupPolicyResourceModel{}
 	diags := flattenBackupPolicy(context.Background(), policy, policySchemaType(t), &data)
-	require.True(t, diags.HasError(), "AWS_NATIVE_STANDARD should be rejected")
-	assert.Contains(t, diags.Errors()[0].Detail(), "AWS_NATIVE_STANDARD")
+	require.True(t, diags.HasError(), "AZURE_FILES_STANDARD should be rejected")
+	assert.Contains(t, diags.Errors()[0].Detail(), "AZURE_FILES_STANDARD")
+}
+
+func awsNativeStandardPolicy(schedules ...externalEonSdkAPI.AwsNativeStandardBackupSchedules) *externalEonSdkAPI.BackupPolicy {
+	selector := externalEonSdkAPI.NewBackupPolicyResourceSelector(externalEonSdkAPI.RESOURCE_SELECTOR_MODE_ALL)
+	nativePlan := externalEonSdkAPI.NewAwsNativeStandardBackupPolicyPlan(schedules)
+	plan := externalEonSdkAPI.NewBackupPolicyPlan(externalEonSdkAPI.BACKUP_POLICY_TYPE_AWS_NATIVE_STANDARD)
+	plan.SetAwsNativeStandardPlan(*nativePlan)
+
+	return externalEonSdkAPI.NewBackupPolicy("policy-native", "efs-nightly", true, *selector, *plan)
+}
+
+func awsNativeDailySchedule(targetRegion string, retentionDays int32) externalEonSdkAPI.AwsNativeStandardBackupSchedules {
+	dailyConfig := externalEonSdkAPI.NewDailyConfig()
+	dailyConfig.SetTimeOfDay(*externalEonSdkAPI.NewTimeOfDay(2, 30))
+
+	scheduleConfig := externalEonSdkAPI.NewAwsNativeStandardBackupScheduleConfig(externalEonSdkAPI.STANDARD_BACKUP_SCHEDULE_DAILY)
+	scheduleConfig.SetDailyConfig(*dailyConfig)
+
+	return *externalEonSdkAPI.NewAwsNativeStandardBackupSchedules(targetRegion, *scheduleConfig, retentionDays)
+}
+
+func TestFlattenBackupPolicy_AwsNativeStandardPlan(t *testing.T) {
+	t.Parallel()
+
+	data := BackupPolicyResourceModel{}
+	diags := flattenBackupPolicy(context.Background(), awsNativeStandardPolicy(awsNativeDailySchedule("us-east-1", 30)),
+		policySchemaType(t), &data)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags.Errors())
+
+	assert.Equal(t, types.StringValue("AWS_NATIVE_STANDARD"), nestedValue(t, data.BackupPlan, "backup_policy_type"))
+	assert.Equal(t, types.StringValue("us-east-1"),
+		nestedValue(t, data.BackupPlan, "aws_native_standard_plan", "backup_schedules", "target_region"))
+	assert.Equal(t, types.Int64Value(30),
+		nestedValue(t, data.BackupPlan, "aws_native_standard_plan", "backup_schedules", "retention_days"))
+	assert.Equal(t, types.Int64Value(2),
+		nestedValue(t, data.BackupPlan, "aws_native_standard_plan", "backup_schedules", "schedule_config", "daily_config", "time_of_day_hour"))
+	assert.True(t, nestedValue(t, data.BackupPlan, "standard_plan").IsNull())
+}
+
+// TestFlattenBackupPolicy_AwsNativeStandardSourceRegion pins the source-region case: the API reports
+// an empty target region, which the configuration expresses by omitting target_region entirely.
+func TestFlattenBackupPolicy_AwsNativeStandardSourceRegion(t *testing.T) {
+	t.Parallel()
+
+	data := BackupPolicyResourceModel{}
+	diags := flattenBackupPolicy(context.Background(), awsNativeStandardPolicy(awsNativeDailySchedule("", 30)),
+		policySchemaType(t), &data)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags.Errors())
+
+	assert.True(t, nestedValue(t, data.BackupPlan, "aws_native_standard_plan", "backup_schedules", "target_region").IsNull())
+}
+
+func TestFlattenBackupPolicy_AwsNativeStandardInterval(t *testing.T) {
+	t.Parallel()
+
+	scheduleConfig := externalEonSdkAPI.NewAwsNativeStandardBackupScheduleConfig(externalEonSdkAPI.STANDARD_BACKUP_SCHEDULE_INTERVAL)
+	scheduleConfig.SetIntervalConfig(*externalEonSdkAPI.NewAwsNativeStandardIntervalConfig(2))
+	schedule := externalEonSdkAPI.NewAwsNativeStandardBackupSchedules("us-west-2", *scheduleConfig, 7)
+
+	data := BackupPolicyResourceModel{}
+	diags := flattenBackupPolicy(context.Background(), awsNativeStandardPolicy(*schedule), policySchemaType(t), &data)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags.Errors())
+
+	assert.Equal(t, types.Int64Value(2),
+		nestedValue(t, data.BackupPlan, "aws_native_standard_plan", "backup_schedules", "schedule_config", "interval_config", "interval_hours"))
+}
+
+func TestFlattenBackupPolicy_AwsNativeStandardWithoutPlan(t *testing.T) {
+	t.Parallel()
+
+	policy := standardPolicy(dailyScheduleConfig(1, 0))
+	policy.BackupPlan.BackupPolicyType = externalEonSdkAPI.BACKUP_POLICY_TYPE_AWS_NATIVE_STANDARD
+	policy.BackupPlan.UnsetStandardPlan()
+
+	data := BackupPolicyResourceModel{}
+	diags := flattenBackupPolicy(context.Background(), policy, policySchemaType(t), &data)
+	require.True(t, diags.HasError(), "a native standard policy without its plan should be reported")
+	assert.Contains(t, diags.Errors()[0].Detail(), "without an AWS native standard plan")
 }
 
 // TestFlattenIntervalConfig_KeepsConfiguredUnit pins the ambiguity that makes a naive refresh diff

--- a/internal/provider/data_source_backup_policies.go
+++ b/internal/provider/data_source_backup_policies.go
@@ -60,7 +60,7 @@ func (d *BackupPoliciesDataSource) Schema(ctx context.Context, req datasource.Sc
 							Computed:            true,
 						},
 						"backup_policy_type": schema.StringAttribute{
-							MarkdownDescription: "The type of the policy. Possible values: `UNSPECIFIED`, `STANDARD`, `HIGH_FREQUENCY`, `PITR`, `AWS_NATIVE_PITR`.",
+							MarkdownDescription: "The type of the policy. Possible values: `UNSPECIFIED`, `STANDARD`, `HIGH_FREQUENCY`, `PITR`, `AWS_NATIVE_PITR`, `AWS_NATIVE_STANDARD`.",
 							Computed:            true,
 						},
 						"resource_selection_mode": schema.StringAttribute{

--- a/internal/provider/resource_backup_policy.go
+++ b/internal/provider/resource_backup_policy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -1621,7 +1620,7 @@ func validateAwsNativeStandardInterval(schedulePath path.Path, intervalValue att
 		return
 	}
 
-	if hours > math.MaxInt32 || !allowedInterval(int32(hours), awsNativeStandardIntervalHours) {
+	if !allowedInterval(hours, awsNativeStandardIntervalHours) {
 		resp.Diagnostics.AddAttributeError(intervalPath, "Invalid interval",
 			fmt.Sprintf("AWS source-account backup interval must be %s hours, got %d hours",
 				intervalHoursList(awsNativeStandardIntervalHours), hours))
@@ -1692,9 +1691,9 @@ var awsNativeStandardMinRetentionDays = map[string]int64{
 
 const awsNativeStandardMaxRetentionDays = 36500
 
-func allowedInterval(hours int32, allowed []int32) bool {
+func allowedInterval(hours int64, allowed []int32) bool {
 	for _, candidate := range allowed {
-		if hours == candidate {
+		if hours == int64(candidate) {
 			return true
 		}
 	}
@@ -2009,7 +2008,7 @@ func buildStandardScheduleConfig(
 				}
 				intervalHours = intervalMinutes / 60
 
-				if !allowedInterval(intervalHours, allowedIntervalHours) {
+				if !allowedInterval(int64(intervalHours), allowedIntervalHours) {
 					return nil, fmt.Errorf("backup interval must be %s hours, got %d hours (%d minutes)", intervalHoursList(allowedIntervalHours), intervalHours, intervalMinutes)
 				}
 			} else {
@@ -2018,7 +2017,7 @@ func buildStandardScheduleConfig(
 					return nil, fmt.Errorf("invalid interval_hours: %s", err)
 				}
 
-				if !allowedInterval(intervalHours, allowedIntervalHours) {
+				if !allowedInterval(int64(intervalHours), allowedIntervalHours) {
 					return nil, fmt.Errorf("backup interval must be %s hours, got %d hours", intervalHoursList(allowedIntervalHours), intervalHours)
 				}
 			}

--- a/internal/provider/resource_backup_policy.go
+++ b/internal/provider/resource_backup_policy.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	externalEonSdkAPI "github.com/eon-io/eon-sdk-go"
 	"github.com/eon-io/terraform-provider-eon/internal/client"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -64,8 +68,18 @@ type AwsNativePitrPlanModel struct {
 	ResourceType  types.String `tfsdk:"resource_type"`
 }
 
+type AwsNativeStandardPlanModel struct {
+	BackupSchedules types.List `tfsdk:"backup_schedules"`
+}
+
 type BackupScheduleModel struct {
 	VaultId        types.String `tfsdk:"vault_id"`
+	RetentionDays  types.Int64  `tfsdk:"retention_days"`
+	ScheduleConfig types.Object `tfsdk:"schedule_config"`
+}
+
+type AwsNativeStandardScheduleModel struct {
+	TargetRegion   types.String `tfsdk:"target_region"`
 	RetentionDays  types.Int64  `tfsdk:"retention_days"`
 	ScheduleConfig types.Object `tfsdk:"schedule_config"`
 }
@@ -585,7 +599,7 @@ func (r *BackupPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 				Required:            true,
 				Attributes: map[string]schema.Attribute{
 					"backup_policy_type": schema.StringAttribute{
-						MarkdownDescription: "Backup policy type: 'STANDARD', 'HIGH_FREQUENCY', 'PITR', or 'AWS_NATIVE_PITR'",
+						MarkdownDescription: "Backup policy type: 'STANDARD', 'HIGH_FREQUENCY', 'PITR', 'AWS_NATIVE_PITR', or 'AWS_NATIVE_STANDARD'",
 						Required:            true,
 					},
 					"standard_plan": schema.SingleNestedAttribute{
@@ -610,122 +624,10 @@ func (r *BackupPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 											MarkdownDescription: "Retention days",
 											Required:            true,
 										},
-										"schedule_config": schema.SingleNestedAttribute{
-											MarkdownDescription: "Schedule configuration",
-											Required:            true,
-											Attributes: map[string]schema.Attribute{
-												"frequency": schema.StringAttribute{
-													MarkdownDescription: "Frequency: 'DAILY', 'WEEKLY', 'MONTHLY', 'ANNUALLY', 'INTERVAL'",
-													Required:            true,
-												},
-												"daily_config": schema.SingleNestedAttribute{
-													MarkdownDescription: "Daily configuration",
-													Optional:            true,
-													Attributes: map[string]schema.Attribute{
-														"time_of_day_hour": schema.Int64Attribute{
-															MarkdownDescription: "Hour of day (0-23)",
-															Optional:            true,
-														},
-														"time_of_day_minutes": schema.Int64Attribute{
-															MarkdownDescription: "Minutes of hour (0-59)",
-															Optional:            true,
-														},
-														"start_window_minutes": schema.Int64Attribute{
-															MarkdownDescription: "Start window in minutes",
-															Optional:            true,
-														},
-													},
-												},
-												"weekly_config": schema.SingleNestedAttribute{
-													MarkdownDescription: "Weekly configuration",
-													Optional:            true,
-													Attributes: map[string]schema.Attribute{
-														"day_of_week": schema.StringAttribute{
-															MarkdownDescription: "Day of week: 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'",
-															Required:            true,
-														},
-														"time_of_day_hour": schema.Int64Attribute{
-															MarkdownDescription: "Hour of day (0-23)",
-															Optional:            true,
-														},
-														"time_of_day_minutes": schema.Int64Attribute{
-															MarkdownDescription: "Minutes of hour (0-59)",
-															Optional:            true,
-														},
-														"start_window_minutes": schema.Int64Attribute{
-															MarkdownDescription: "Start window in minutes",
-															Optional:            true,
-														},
-													},
-												},
-												"monthly_config": schema.SingleNestedAttribute{
-													MarkdownDescription: "Monthly configuration",
-													Optional:            true,
-													Attributes: map[string]schema.Attribute{
-														"day_of_month": schema.Int64Attribute{
-															MarkdownDescription: "Day of month (1-31)",
-															Required:            true,
-														},
-														"time_of_day_hour": schema.Int64Attribute{
-															MarkdownDescription: "Hour of day (0-23)",
-															Optional:            true,
-														},
-														"time_of_day_minutes": schema.Int64Attribute{
-															MarkdownDescription: "Minutes of hour (0-59)",
-															Optional:            true,
-														},
-														"start_window_minutes": schema.Int64Attribute{
-															MarkdownDescription: "Start window in minutes",
-															Optional:            true,
-														},
-													},
-												},
-												"annually_config": schema.SingleNestedAttribute{
-													MarkdownDescription: "Annually configuration",
-													Optional:            true,
-													Attributes: map[string]schema.Attribute{
-														"month": schema.StringAttribute{
-															MarkdownDescription: "Month: 'JANUARY', 'FEBRUARY', 'MARCH', 'APRIL', 'MAY', 'JUNE', 'JULY', 'AUGUST', 'SEPTEMBER', 'OCTOBER', 'NOVEMBER', 'DECEMBER'",
-															Required:            true,
-														},
-														"day_of_month": schema.Int64Attribute{
-															MarkdownDescription: "Day of month (1-31)",
-															Required:            true,
-														},
-														"time_of_day_hour": schema.Int64Attribute{
-															MarkdownDescription: "Hour of day (0-23)",
-															Optional:            true,
-														},
-														"time_of_day_minutes": schema.Int64Attribute{
-															MarkdownDescription: "Minutes of hour (0-59)",
-															Optional:            true,
-														},
-														"start_window_minutes": schema.Int64Attribute{
-															MarkdownDescription: "Start window in minutes",
-															Optional:            true,
-														},
-													},
-												},
-												"interval_config": schema.SingleNestedAttribute{
-													MarkdownDescription: "Interval configuration. Specify either interval_minutes OR interval_hours (not both)",
-													Optional:            true,
-													Attributes: map[string]schema.Attribute{
-														"interval_minutes": schema.Int64Attribute{
-															MarkdownDescription: "Interval in minutes. Either this or interval_hours must be specified (not both). For STANDARD policies, must be divisible by 60",
-															Optional:            true,
-														},
-														"interval_hours": schema.Int64Attribute{
-															MarkdownDescription: "Interval in hours. Either this or interval_minutes must be specified (not both). More convenient for STANDARD policies",
-															Optional:            true,
-														},
-														"start_window_minutes": schema.Int64Attribute{
-															MarkdownDescription: "Start window in minutes",
-															Optional:            true,
-														},
-													},
-												},
-											},
-										},
+										"schedule_config": scheduleConfigAttribute(
+											"Interval in minutes. Either this or interval_hours must be specified (not both). For STANDARD policies, must be divisible by 60",
+											"Interval in hours. Either this or interval_minutes must be specified (not both). More convenient for STANDARD policies",
+										),
 									},
 								},
 							},
@@ -797,6 +699,33 @@ func (r *BackupPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 							"resource_type": schema.StringAttribute{
 								MarkdownDescription: "Resource type for PITR backup, e.g. 'AWS_RDS'",
 								Required:            true,
+							},
+						},
+					},
+					"aws_native_standard_plan": schema.SingleNestedAttribute{
+						MarkdownDescription: "AWS native standard backup plan, storing snapshots in the AWS source account instead of an Eon vault (mirrors the console's \"Store snapshots in: AWS source account\" destination). Required when backup_policy_type is 'AWS_NATIVE_STANDARD', which is the only way to back up EFS and FSx, whose native backups cannot leave the source account",
+						Optional:            true,
+						Attributes: map[string]schema.Attribute{
+							"backup_schedules": schema.ListNestedAttribute{
+								MarkdownDescription: "List of backup schedules",
+								Required:            true,
+								NestedObject: schema.NestedAttributeObject{
+									Attributes: map[string]schema.Attribute{
+										"target_region": schema.StringAttribute{
+											MarkdownDescription: "AWS region the backups are copied to, e.g. 'us-east-1'. Omit to keep each backup in its resource's own region",
+											Optional:            true,
+										},
+										"retention_days": schema.Int64Attribute{
+											MarkdownDescription: "Retention days. Minimum 1 for DAILY and INTERVAL, 14 for WEEKLY, 60 for MONTHLY, 730 for ANNUALLY; maximum 36500, the AWS Backup ceiling",
+											Required:            true,
+										},
+										"schedule_config": scheduleConfigAttribute(
+											"Interval in minutes. Either this or interval_hours must be specified (not both). Must be divisible by 60",
+											"Interval in hours. Either this or interval_minutes must be specified (not both)",
+										),
+									},
+									Validators: []validator.Object{awsNativeStandardScheduleValidator{}},
+								},
 							},
 						},
 					},
@@ -1057,11 +986,19 @@ func (r *BackupPolicyResource) Create(ctx context.Context, req resource.CreateRe
 		awsNativePitrPlan := externalEonSdkAPI.NewAwsNativePitrBackupPolicyPlan(retentionDays, *resourceType)
 		backupPlan.SetAwsNativePitrPlan(*awsNativePitrPlan)
 
+	case "AWS_NATIVE_STANDARD":
+		awsNativeStandardPlan, planDiags := buildAwsNativeStandardPlan(ctx, backupPlanAttrs)
+		resp.Diagnostics.Append(planDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		backupPlan.SetAwsNativeStandardPlan(*awsNativeStandardPlan)
+
 	default:
 		resp.Diagnostics.AddError(
 			"Unsupported Backup Policy Type",
-			fmt.Sprintf("Backup policy type '%s' is not supported. Supported types: STANDARD, PITR, HIGH_FREQUENCY, AWS_NATIVE_PITR.",
-				backupPolicyType.ValueString()),
+			fmt.Sprintf("Backup policy type '%s' is not supported. Supported types: %s.",
+				backupPolicyType.ValueString(), supportedBackupPolicyTypes),
 		)
 		return
 	}
@@ -1382,11 +1319,19 @@ func (r *BackupPolicyResource) Update(ctx context.Context, req resource.UpdateRe
 		awsNativePitrPlan := externalEonSdkAPI.NewAwsNativePitrBackupPolicyPlan(retentionDays, *resourceType)
 		backupPlan.SetAwsNativePitrPlan(*awsNativePitrPlan)
 
+	case "AWS_NATIVE_STANDARD":
+		awsNativeStandardPlan, planDiags := buildAwsNativeStandardPlan(ctx, backupPlanAttrs)
+		resp.Diagnostics.Append(planDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		backupPlan.SetAwsNativeStandardPlan(*awsNativeStandardPlan)
+
 	default:
 		resp.Diagnostics.AddError(
 			"Unsupported Backup Policy Type",
-			fmt.Sprintf("Backup policy type '%s' is not supported. Supported types: STANDARD, PITR, HIGH_FREQUENCY, AWS_NATIVE_PITR.",
-				backupPolicyType.ValueString()),
+			fmt.Sprintf("Backup policy type '%s' is not supported. Supported types: %s.",
+				backupPolicyType.ValueString(), supportedBackupPolicyTypes),
 		)
 		return
 	}
@@ -1476,6 +1421,221 @@ func createDailyConfigFromModel(data *DailyConfigModel) (*externalEonSdkAPI.Dail
 	return dailyConfig, nil
 }
 
+// scheduleConfigAttribute builds the frequency configuration shared by the vault-backed standard
+// schedules and the AWS source-account schedules, which differ only in the intervals they accept.
+func scheduleConfigAttribute(intervalMinutesDescription, intervalHoursDescription string) schema.SingleNestedAttribute {
+	return schema.SingleNestedAttribute{
+		MarkdownDescription: "Schedule configuration",
+		Required:            true,
+		Attributes: map[string]schema.Attribute{
+			"frequency": schema.StringAttribute{
+				MarkdownDescription: "Frequency: 'DAILY', 'WEEKLY', 'MONTHLY', 'ANNUALLY', 'INTERVAL'",
+				Required:            true,
+			},
+			"daily_config": schema.SingleNestedAttribute{
+				MarkdownDescription: "Daily configuration",
+				Optional:            true,
+				Attributes: map[string]schema.Attribute{
+					"time_of_day_hour": schema.Int64Attribute{
+						MarkdownDescription: "Hour of day (0-23)",
+						Optional:            true,
+					},
+					"time_of_day_minutes": schema.Int64Attribute{
+						MarkdownDescription: "Minutes of hour (0-59)",
+						Optional:            true,
+					},
+					"start_window_minutes": schema.Int64Attribute{
+						MarkdownDescription: "Start window in minutes",
+						Optional:            true,
+					},
+				},
+			},
+			"weekly_config": schema.SingleNestedAttribute{
+				MarkdownDescription: "Weekly configuration",
+				Optional:            true,
+				Attributes: map[string]schema.Attribute{
+					"day_of_week": schema.StringAttribute{
+						MarkdownDescription: "Day of week: 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'",
+						Required:            true,
+					},
+					"time_of_day_hour": schema.Int64Attribute{
+						MarkdownDescription: "Hour of day (0-23)",
+						Optional:            true,
+					},
+					"time_of_day_minutes": schema.Int64Attribute{
+						MarkdownDescription: "Minutes of hour (0-59)",
+						Optional:            true,
+					},
+					"start_window_minutes": schema.Int64Attribute{
+						MarkdownDescription: "Start window in minutes",
+						Optional:            true,
+					},
+				},
+			},
+			"monthly_config": schema.SingleNestedAttribute{
+				MarkdownDescription: "Monthly configuration",
+				Optional:            true,
+				Attributes: map[string]schema.Attribute{
+					"day_of_month": schema.Int64Attribute{
+						MarkdownDescription: "Day of month (1-31)",
+						Required:            true,
+					},
+					"time_of_day_hour": schema.Int64Attribute{
+						MarkdownDescription: "Hour of day (0-23)",
+						Optional:            true,
+					},
+					"time_of_day_minutes": schema.Int64Attribute{
+						MarkdownDescription: "Minutes of hour (0-59)",
+						Optional:            true,
+					},
+					"start_window_minutes": schema.Int64Attribute{
+						MarkdownDescription: "Start window in minutes",
+						Optional:            true,
+					},
+				},
+			},
+			"annually_config": schema.SingleNestedAttribute{
+				MarkdownDescription: "Annually configuration",
+				Optional:            true,
+				Attributes: map[string]schema.Attribute{
+					"month": schema.StringAttribute{
+						MarkdownDescription: "Month: 'JANUARY', 'FEBRUARY', 'MARCH', 'APRIL', 'MAY', 'JUNE', 'JULY', 'AUGUST', 'SEPTEMBER', 'OCTOBER', 'NOVEMBER', 'DECEMBER'",
+						Required:            true,
+					},
+					"day_of_month": schema.Int64Attribute{
+						MarkdownDescription: "Day of month (1-31)",
+						Required:            true,
+					},
+					"time_of_day_hour": schema.Int64Attribute{
+						MarkdownDescription: "Hour of day (0-23)",
+						Optional:            true,
+					},
+					"time_of_day_minutes": schema.Int64Attribute{
+						MarkdownDescription: "Minutes of hour (0-59)",
+						Optional:            true,
+					},
+					"start_window_minutes": schema.Int64Attribute{
+						MarkdownDescription: "Start window in minutes",
+						Optional:            true,
+					},
+				},
+			},
+			"interval_config": schema.SingleNestedAttribute{
+				MarkdownDescription: "Interval configuration. Specify either interval_minutes OR interval_hours (not both)",
+				Optional:            true,
+				Attributes: map[string]schema.Attribute{
+					"interval_minutes": schema.Int64Attribute{
+						MarkdownDescription: intervalMinutesDescription,
+						Optional:            true,
+					},
+					"interval_hours": schema.Int64Attribute{
+						MarkdownDescription: intervalHoursDescription,
+						Optional:            true,
+					},
+					"start_window_minutes": schema.Int64Attribute{
+						MarkdownDescription: "Start window in minutes",
+						Optional:            true,
+					},
+				},
+			},
+		},
+	}
+}
+
+// awsNativeStandardScheduleValidator reports the interval and retention limits AWS Backup enforces
+// while the practitioner is still looking at a plan, instead of letting the apply fail on the API.
+type awsNativeStandardScheduleValidator struct{}
+
+func (awsNativeStandardScheduleValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("interval must be one of %s hours and retention must respect the per-frequency minimum",
+		intervalHoursList(awsNativeStandardIntervalHours))
+}
+
+func (v awsNativeStandardScheduleValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (awsNativeStandardScheduleValidator) ValidateObject(_ context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	scheduleAttrs := req.ConfigValue.Attributes()
+	scheduleConfig, ok := scheduleAttrs["schedule_config"].(types.Object)
+	if !ok || scheduleConfig.IsNull() || scheduleConfig.IsUnknown() {
+		return
+	}
+
+	configAttrs := scheduleConfig.Attributes()
+	frequencyValue, ok := configAttrs["frequency"].(types.String)
+	if !ok || frequencyValue.IsNull() || frequencyValue.IsUnknown() {
+		return
+	}
+	frequency := frequencyValue.ValueString()
+
+	if frequency == "INTERVAL" {
+		validateAwsNativeStandardInterval(req.Path, configAttrs["interval_config"], resp)
+	}
+
+	retention, ok := scheduleAttrs["retention_days"].(types.Int64)
+	if !ok || retention.IsNull() || retention.IsUnknown() {
+		return
+	}
+
+	days := retention.ValueInt64()
+	if minimum, known := awsNativeStandardMinRetentionDays[frequency]; known && days < minimum {
+		resp.Diagnostics.AddAttributeError(req.Path.AtName("retention_days"), "Invalid retention_days",
+			fmt.Sprintf("AWS source-account %s backups require at least %d retention days, got %d", frequency, minimum, days))
+	}
+	if days > awsNativeStandardMaxRetentionDays {
+		resp.Diagnostics.AddAttributeError(req.Path.AtName("retention_days"), "Invalid retention_days",
+			fmt.Sprintf("retention_days must not exceed %d, got %d", awsNativeStandardMaxRetentionDays, days))
+	}
+}
+
+func validateAwsNativeStandardInterval(schedulePath path.Path, intervalValue attr.Value, resp *validator.ObjectResponse) {
+	intervalConfig, ok := intervalValue.(types.Object)
+	if !ok || intervalConfig.IsNull() || intervalConfig.IsUnknown() {
+		return
+	}
+	intervalPath := schedulePath.AtName("schedule_config").AtName("interval_config")
+
+	intervalAttrs := intervalConfig.Attributes()
+	minutes, hasMinutes := knownInt64(intervalAttrs["interval_minutes"])
+	hours, hasHours := knownInt64(intervalAttrs["interval_hours"])
+
+	if hasMinutes && hasHours {
+		resp.Diagnostics.AddAttributeError(intervalPath, "Conflicting interval",
+			"Specify either interval_minutes or interval_hours, not both")
+		return
+	}
+
+	if hasMinutes {
+		if minutes%60 != 0 {
+			resp.Diagnostics.AddAttributeError(intervalPath.AtName("interval_minutes"), "Invalid interval_minutes",
+				fmt.Sprintf("interval_minutes must be divisible by 60, got %d", minutes))
+			return
+		}
+		hours = minutes / 60
+	} else if !hasHours {
+		return
+	}
+
+	if hours > math.MaxInt32 || !allowedInterval(int32(hours), awsNativeStandardIntervalHours) {
+		resp.Diagnostics.AddAttributeError(intervalPath, "Invalid interval",
+			fmt.Sprintf("AWS source-account backup interval must be %s hours, got %d hours",
+				intervalHoursList(awsNativeStandardIntervalHours), hours))
+	}
+}
+
+func knownInt64(value attr.Value) (int64, bool) {
+	typed, ok := value.(types.Int64)
+	if !ok || typed.IsNull() || typed.IsUnknown() {
+		return 0, false
+	}
+	return typed.ValueInt64(), true
+}
+
 // scheduleTimezoneValidator rejects values outside the SDK's allowed set at plan time. Without it a
 // typo would silently map to UTC on the server (the enum is x-extensible, so unknown values are not
 // rejected there). Sourced from the SDK enum so it stays correct if the allowed set grows.
@@ -1511,9 +1671,140 @@ func applyScheduleTimezone(plan *externalEonSdkAPI.StandardBackupPolicyPlan, tz 
 	}
 }
 
+const supportedBackupPolicyTypes = "STANDARD, PITR, HIGH_FREQUENCY, AWS_NATIVE_PITR, AWS_NATIVE_STANDARD"
+
+// Vault-backed standard policies only accept the three intervals the console offers, while AWS
+// source-account policies map onto AWS Backup rules and accept the shorter ones too.
+var (
+	standardIntervalHours          = []int32{6, 8, 12}
+	awsNativeStandardIntervalHours = []int32{1, 2, 4, 6, 8, 12}
+)
+
+// AWS Backup enforces a retention floor per frequency, so a rejected plan is worth catching before
+// the apply reaches the API.
+var awsNativeStandardMinRetentionDays = map[string]int64{
+	"DAILY":    1,
+	"INTERVAL": 1,
+	"WEEKLY":   14,
+	"MONTHLY":  60,
+	"ANNUALLY": 730,
+}
+
+const awsNativeStandardMaxRetentionDays = 36500
+
+func allowedInterval(hours int32, allowed []int32) bool {
+	for _, candidate := range allowed {
+		if hours == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func intervalHoursList(allowed []int32) string {
+	parts := make([]string, 0, len(allowed))
+	for _, hours := range allowed {
+		parts = append(parts, strconv.FormatInt(int64(hours), 10))
+	}
+	if len(parts) < 2 {
+		return strings.Join(parts, "")
+	}
+	return strings.Join(parts[:len(parts)-1], ", ") + ", or " + parts[len(parts)-1]
+}
+
+// buildAwsNativeStandardPlan converts the aws_native_standard_plan block into the API plan whose
+// schedules stay in the AWS source account, keyed by target region instead of an Eon vault.
+func buildAwsNativeStandardPlan(
+	ctx context.Context,
+	backupPlanAttrs map[string]attr.Value,
+) (*externalEonSdkAPI.AwsNativeStandardBackupPolicyPlan, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	planObj, err := requiredPlanObject(backupPlanAttrs, "aws_native_standard_plan", "AWS_NATIVE_STANDARD")
+	if err != nil {
+		diags.AddError("Missing AWS Native Standard Plan", err.Error())
+		return nil, diags
+	}
+
+	var planModel AwsNativeStandardPlanModel
+	diags.Append(planObj.As(ctx, &planModel, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	var schedules []AwsNativeStandardScheduleModel
+	diags.Append(planModel.BackupSchedules.ElementsAs(ctx, &schedules, false)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	backupSchedules := make([]externalEonSdkAPI.AwsNativeStandardBackupSchedules, 0, len(schedules))
+	for _, schedule := range schedules {
+		scheduleConfig, configErr := createAwsNativeStandardScheduleConfig(&schedule)
+		if configErr != nil {
+			diags.AddError(
+				"Invalid Schedule Configuration",
+				fmt.Sprintf("Failed to create AWS native standard schedule configuration: %s", configErr),
+			)
+			return nil, diags
+		}
+
+		retentionDays, retentionErr := SafeInt32Conversion(schedule.RetentionDays.ValueInt64())
+		if retentionErr != nil {
+			diags.AddError("Invalid Retention Days", fmt.Sprintf("Failed to validate retention days: %s", retentionErr))
+			return nil, diags
+		}
+
+		backupSchedules = append(backupSchedules, *externalEonSdkAPI.NewAwsNativeStandardBackupSchedules(
+			schedule.TargetRegion.ValueString(),
+			*scheduleConfig,
+			retentionDays,
+		))
+	}
+
+	return externalEonSdkAPI.NewAwsNativeStandardBackupPolicyPlan(backupSchedules), nil
+}
+
+// createAwsNativeStandardScheduleConfig reuses the standard frequency configuration and re-keys it
+// onto the AWS native schedule type, which differs only in the intervals it accepts.
+func createAwsNativeStandardScheduleConfig(
+	schedule *AwsNativeStandardScheduleModel,
+) (*externalEonSdkAPI.AwsNativeStandardBackupScheduleConfig, error) {
+	standardConfig, err := buildStandardScheduleConfig(schedule.ScheduleConfig, awsNativeStandardIntervalHours)
+	if err != nil {
+		return nil, err
+	}
+
+	config := externalEonSdkAPI.NewAwsNativeStandardBackupScheduleConfig(standardConfig.Frequency)
+	if interval := standardConfig.IntervalConfig.Get(); interval != nil {
+		config.SetIntervalConfig(*externalEonSdkAPI.NewAwsNativeStandardIntervalConfig(interval.IntervalHours))
+	}
+	if daily := standardConfig.DailyConfig.Get(); daily != nil {
+		config.SetDailyConfig(*daily)
+	}
+	if weekly := standardConfig.WeeklyConfig.Get(); weekly != nil {
+		config.SetWeeklyConfig(*weekly)
+	}
+	if monthly := standardConfig.MonthlyConfig.Get(); monthly != nil {
+		config.SetMonthlyConfig(*monthly)
+	}
+	if annually := standardConfig.AnnuallyConfig.Get(); annually != nil {
+		config.SetAnnuallyConfig(*annually)
+	}
+
+	return config, nil
+}
+
 // createStandardScheduleConfig creates a StandardBackupScheduleConfig based on the policy type and frequency
 func createStandardScheduleConfig(schedule *BackupScheduleModel) (*externalEonSdkAPI.StandardBackupScheduleConfig, error) {
-	scheduleConfigAttrs := schedule.ScheduleConfig.Attributes()
+	return buildStandardScheduleConfig(schedule.ScheduleConfig, standardIntervalHours)
+}
+
+func buildStandardScheduleConfig(
+	scheduleConfigObj types.Object,
+	allowedIntervalHours []int32,
+) (*externalEonSdkAPI.StandardBackupScheduleConfig, error) {
+	scheduleConfigAttrs := scheduleConfigObj.Attributes()
 	frequencyObj := scheduleConfigAttrs["frequency"]
 	if frequencyObj == nil {
 		return nil, fmt.Errorf("frequency field is required in schedule config")
@@ -1718,8 +2009,8 @@ func createStandardScheduleConfig(schedule *BackupScheduleModel) (*externalEonSd
 				}
 				intervalHours = intervalMinutes / 60
 
-				if intervalHours != 6 && intervalHours != 8 && intervalHours != 12 {
-					return nil, fmt.Errorf("standard backup interval must be 6, 8, or 12 hours (360, 480, or 720 minutes), got %d hours (%d minutes)", intervalHours, intervalMinutes)
+				if !allowedInterval(intervalHours, allowedIntervalHours) {
+					return nil, fmt.Errorf("backup interval must be %s hours, got %d hours (%d minutes)", intervalHoursList(allowedIntervalHours), intervalHours, intervalMinutes)
 				}
 			} else {
 				intervalHours, err = SafeInt32Conversion(intervalHoursObj.(types.Int64).ValueInt64())
@@ -1727,8 +2018,8 @@ func createStandardScheduleConfig(schedule *BackupScheduleModel) (*externalEonSd
 					return nil, fmt.Errorf("invalid interval_hours: %s", err)
 				}
 
-				if intervalHours != 6 && intervalHours != 8 && intervalHours != 12 {
-					return nil, fmt.Errorf("standard backup interval must be 6, 8, or 12 hours, got %d hours", intervalHours)
+				if !allowedInterval(intervalHours, allowedIntervalHours) {
+					return nil, fmt.Errorf("backup interval must be %s hours, got %d hours", intervalHoursList(allowedIntervalHours), intervalHours)
 				}
 			}
 

--- a/internal/provider/resource_backup_policy_unit_test.go
+++ b/internal/provider/resource_backup_policy_unit_test.go
@@ -7,9 +7,12 @@ import (
 
 	externalEonSdkAPI "github.com/eon-io/eon-sdk-go"
 	"github.com/eon-io/terraform-provider-eon/internal/client"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestBackupPolicyResource_Unit tests the backup policy resource without API calls
@@ -888,6 +891,177 @@ func TestApplyScheduleTimezone(t *testing.T) {
 			assert.Equal(t, tt.want, *got)
 		})
 	}
+}
+
+func awsNativeIntervalSchedule(t *testing.T, retentionDays int64, frequency string, intervalAttrs map[string]attr.Value) types.Object {
+	t.Helper()
+
+	scheduleType, diags := nestedListElementType(awsNativeStandardPlanType(t), "backup_schedules")
+	require.False(t, diags.HasError())
+	configType, diags := nestedObjectType(scheduleType, "schedule_config")
+	require.False(t, diags.HasError())
+	intervalType, diags := nestedObjectType(configType, "interval_config")
+	require.False(t, diags.HasError())
+
+	interval := types.ObjectNull(intervalType.AttrTypes)
+	if intervalAttrs != nil {
+		interval, diags = objectValue(intervalType, intervalAttrs)
+		require.False(t, diags.HasError())
+	}
+
+	config, diags := objectValue(configType, map[string]attr.Value{
+		"frequency":       types.StringValue(frequency),
+		"interval_config": interval,
+	})
+	require.False(t, diags.HasError())
+
+	schedule, diags := objectValue(scheduleType, map[string]attr.Value{
+		"retention_days":  types.Int64Value(retentionDays),
+		"schedule_config": config,
+	})
+	require.False(t, diags.HasError())
+	return schedule
+}
+
+func awsNativeStandardPlanType(t *testing.T) types.ObjectType {
+	t.Helper()
+
+	planType, diags := nestedObjectType(policySchemaType(t), "backup_plan")
+	require.False(t, diags.HasError())
+	nativeType, diags := nestedObjectType(planType, "aws_native_standard_plan")
+	require.False(t, diags.HasError())
+	return nativeType
+}
+
+func TestAwsNativeStandardScheduleValidator(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		schedule      types.Object
+		wantErr       bool
+		errorContains string
+	}{
+		{
+			name:     "hourly interval is allowed",
+			schedule: awsNativeIntervalSchedule(t, 7, "INTERVAL", map[string]attr.Value{"interval_hours": types.Int64Value(1)}),
+		},
+		{
+			name:     "minutes convert to an allowed interval",
+			schedule: awsNativeIntervalSchedule(t, 7, "INTERVAL", map[string]attr.Value{"interval_minutes": types.Int64Value(240)}),
+		},
+		{
+			name:          "three hours is rejected",
+			schedule:      awsNativeIntervalSchedule(t, 7, "INTERVAL", map[string]attr.Value{"interval_hours": types.Int64Value(3)}),
+			wantErr:       true,
+			errorContains: "1, 2, 4, 6, 8, or 12 hours",
+		},
+		{
+			name:          "minutes must be whole hours",
+			schedule:      awsNativeIntervalSchedule(t, 7, "INTERVAL", map[string]attr.Value{"interval_minutes": types.Int64Value(90)}),
+			wantErr:       true,
+			errorContains: "divisible by 60",
+		},
+		{
+			name: "both interval units are rejected",
+			schedule: awsNativeIntervalSchedule(t, 7, "INTERVAL", map[string]attr.Value{
+				"interval_hours":   types.Int64Value(2),
+				"interval_minutes": types.Int64Value(120),
+			}),
+			wantErr:       true,
+			errorContains: "not both",
+		},
+		{
+			name:     "daily accepts a single day",
+			schedule: awsNativeIntervalSchedule(t, 1, "DAILY", nil),
+		},
+		{
+			name:          "weekly below the AWS floor is rejected",
+			schedule:      awsNativeIntervalSchedule(t, 13, "WEEKLY", nil),
+			wantErr:       true,
+			errorContains: "at least 14 retention days",
+		},
+		{
+			name:          "monthly below the AWS floor is rejected",
+			schedule:      awsNativeIntervalSchedule(t, 59, "MONTHLY", nil),
+			wantErr:       true,
+			errorContains: "at least 60 retention days",
+		},
+		{
+			name:          "annual below the AWS floor is rejected",
+			schedule:      awsNativeIntervalSchedule(t, 729, "ANNUALLY", nil),
+			wantErr:       true,
+			errorContains: "at least 730 retention days",
+		},
+		{
+			name:          "retention above the AWS ceiling is rejected",
+			schedule:      awsNativeIntervalSchedule(t, 36501, "DAILY", nil),
+			wantErr:       true,
+			errorContains: "must not exceed 36500",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := &validator.ObjectResponse{}
+			awsNativeStandardScheduleValidator{}.ValidateObject(
+				context.Background(),
+				validator.ObjectRequest{Path: path.Root("backup_plan"), ConfigValue: tt.schedule},
+				resp,
+			)
+			assert.Equal(t, tt.wantErr, resp.Diagnostics.HasError(), "diagnostics: %v", resp.Diagnostics.Errors())
+			if tt.errorContains != "" {
+				require.True(t, resp.Diagnostics.HasError())
+				assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), tt.errorContains)
+			}
+		})
+	}
+}
+
+// TestBuildAwsNativeStandardPlan covers the create and update request the provider sends for a
+// source-account policy: schedules carry a target region instead of a vault, and the interval is
+// expressed in hours whichever unit the configuration used.
+func TestBuildAwsNativeStandardPlan(t *testing.T) {
+	t.Parallel()
+
+	planType := awsNativeStandardPlanType(t)
+	scheduleType, diags := nestedListElementType(planType, "backup_schedules")
+	require.False(t, diags.HasError())
+
+	schedule := awsNativeIntervalSchedule(t, 7, "INTERVAL", map[string]attr.Value{"interval_minutes": types.Int64Value(240)})
+	scheduleAttrs := schedule.Attributes()
+	scheduleAttrs["target_region"] = types.StringValue("us-east-1")
+	schedule, diags = objectValue(scheduleType, scheduleAttrs)
+	require.False(t, diags.HasError())
+
+	scheduleList, diags := types.ListValue(scheduleType, []attr.Value{schedule})
+	require.False(t, diags.HasError())
+
+	planObject, diags := objectValue(planType, map[string]attr.Value{"backup_schedules": scheduleList})
+	require.False(t, diags.HasError())
+
+	plan, planDiags := buildAwsNativeStandardPlan(context.Background(),
+		map[string]attr.Value{"aws_native_standard_plan": planObject})
+	require.False(t, planDiags.HasError(), "unexpected diagnostics: %v", planDiags.Errors())
+
+	require.Len(t, plan.BackupSchedules, 1)
+	built := plan.BackupSchedules[0]
+	assert.Equal(t, "us-east-1", built.TargetRegion)
+	assert.Equal(t, int32(7), built.BackupRetentionDays)
+	assert.Equal(t, externalEonSdkAPI.STANDARD_BACKUP_SCHEDULE_INTERVAL, built.ScheduleConfig.Frequency)
+	require.NotNil(t, built.ScheduleConfig.IntervalConfig.Get())
+	assert.Equal(t, int32(4), built.ScheduleConfig.IntervalConfig.Get().IntervalHours)
+}
+
+func TestBuildAwsNativeStandardPlan_MissingPlan(t *testing.T) {
+	t.Parallel()
+
+	_, diags := buildAwsNativeStandardPlan(context.Background(),
+		map[string]attr.Value{"aws_native_standard_plan": types.ObjectNull(awsNativeStandardPlanType(t).AttrTypes)})
+	require.True(t, diags.HasError())
+	assert.Contains(t, diags.Errors()[0].Detail(), "aws_native_standard_plan is required")
 }
 
 func TestScheduleTimezoneValidator(t *testing.T) {


### PR DESCRIPTION
## Summary

The console's "Store snapshots in" selector is not a field on a schedule — it picks the policy type. `aws-source-account` maps to `AWS_NATIVE_STANDARD`, whose schedules are keyed by `targetRegion` and have no vault, which is why EFS/FSx (whose native backups cannot leave the source account) were unmanageable from Terraform. This adds that policy type as its own plan block rather than a destination field on `standard_plan`:

```hcl
backup_plan = {
  backup_policy_type = "AWS_NATIVE_STANDARD"
  aws_native_standard_plan = {
    backup_schedules = [{
      target_region  = "us-east-1" # omit to keep backups in the resource's own region
      retention_days = 30
      schedule_config = { frequency = "DAILY", daily_config = { ... } }
    }]
  }
}
```

Notable points beyond the plumbing:

- `schedule_config` is now built once by `scheduleConfigAttribute(intervalMinutesDesc, intervalHoursDesc)` and shared by `standard_plan` and `aws_native_standard_plan`; the two differ only in which intervals they accept. `createStandardScheduleConfig` keeps its signature and delegates to `buildStandardScheduleConfig(configObj, allowedIntervalHours)` — `{6, 8, 12}` for vault-backed, `{1, 2, 4, 6, 8, 12}` for source-account.
- Conversion and flattening go through the standard schedule config in both directions (`createAwsNativeStandardScheduleConfig`, `awsNativeStandardScheduleConfigAsStandard`), since the native type shares every frequency config and differs only in its interval type. That reuses the existing interval-unit preservation, so a config written in `interval_minutes` does not refresh into `interval_hours`.
- `awsNativeStandardScheduleValidator` reports AWS Backup's limits at plan time instead of on apply: interval hours from the allowed set, and retention floors per frequency (daily/interval 1, weekly 14, monthly 60, annual 730) with a 36500 ceiling.
- Refresh maps an empty `targetRegion` back to a null `target_region`, because the source-region case is expressed by omitting the attribute and writing `""` would read as permanent drift.
- `vault_protection_mode` is deliberately not exposed. Azure subscription parity (`AZURE_FILES`) is blocked on the API being `x-internal` and is tracked separately in EON-17521.

Tests cover the new validator, the create/update request shape, and the flatten paths (region, source region, interval, missing plan). The old `TestFlattenBackupPolicy_RejectsUnsupportedPolicyType` now asserts on `AZURE_FILES_STANDARD`, which remains unrepresentable.


Link to Devin session: https://eon.devinenterprise.com/sessions/dd70894e2f714ac495e7bb644e5bb306
Requested by: @oryanomer1