### PR TITLE
feat(backup-policy): support nested AND/OR groups in resource selectors

### DIFF
--- a/docs/resources/backup_policy.md
+++ b/docs/resources/backup_policy.md
@@ -497,6 +497,124 @@ resource "eon_backup_policy" "all_condition_types" {
   }
 }
 
+# Example: Nested groups — exclude specific RDS and DynamoDB names (matches console AND → OR → AND)
+# Logic: account/region/tag/type filters AND (
+#   (type=RDS AND name does not contain exclude) OR
+#   (type=DynamoDB AND name does not contain exclude)
+# )
+resource "eon_backup_policy" "exclude_by_type_and_name" {
+  name    = "Standard Backup Excluding Test Resources"
+  enabled = true
+
+  resource_selector = {
+    resource_selection_mode = "CONDITIONAL"
+
+    expression = {
+      group = {
+        operator = "AND"
+        operands = [
+          {
+            account_id = {
+              operator    = "IN"
+              account_ids = ["123456789012"]
+            }
+          },
+          {
+            source_region = {
+              operator       = "IN"
+              source_regions = ["us-east-1"]
+            }
+          },
+          {
+            tag_key_values = {
+              operator = "CONTAINS_ANY_OF"
+              tag_key_values = [
+                {
+                  key   = "m_tier"
+                  value = "1"
+                }
+              ]
+            }
+          },
+          {
+            resource_type = {
+              operator       = "IN"
+              resource_types = ["AWS_RDS", "AWS_DYNAMO_DB"]
+            }
+          },
+          {
+            # Type-scoped name excludes: nested OR of (type AND name NOT_CONTAINS)
+            group = {
+              operator = "OR"
+              operands = [
+                {
+                  group = {
+                    operator = "AND"
+                    operands = [
+                      {
+                        resource_type = {
+                          operator       = "IN"
+                          resource_types = ["AWS_RDS"]
+                        }
+                      },
+                      {
+                        resource_name = {
+                          operator       = "NOT_CONTAINS"
+                          resource_names = ["db-test-users"]
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  group = {
+                    operator = "AND"
+                    operands = [
+                      {
+                        resource_type = {
+                          operator       = "IN"
+                          resource_types = ["AWS_DYNAMO_DB"]
+                        }
+                      },
+                      {
+                        resource_name = {
+                          operator       = "NOT_CONTAINS"
+                          resource_names = ["lab-test-claims-events"]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+
+  backup_plan = {
+    backup_policy_type = "STANDARD"
+    standard_plan = {
+      schedule_timezone = "RESOURCE"
+      backup_schedules = [
+        {
+          vault_id       = "e19a6ad1-6a97-49a1-b7c9-9620977ea018"
+          retention_days = 30
+          schedule_config = {
+            frequency = "DAILY"
+            daily_config = {
+              time_of_day_hour     = 2
+              time_of_day_minutes  = 0
+              start_window_minutes = 240
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
 # Output examples
 output "daily_backup_policy_id" {
   description = "ID of the daily backup policy"
@@ -541,6 +659,11 @@ output "conditional_backup_policy_id" {
 output "all_condition_types_policy_id" {
   description = "ID of the policy demonstrating all condition types"
   value       = eon_backup_policy.all_condition_types.id
+}
+
+output "exclude_by_type_and_name_policy_id" {
+  description = "ID of the nested-group exclude-by-type-and-name policy"
+  value       = eon_backup_policy.exclude_by_type_and_name.id
 }
 
 output "backup_policies_summary" {
@@ -590,6 +713,11 @@ output "backup_policies_summary" {
       id      = eon_backup_policy.all_condition_types.id
       name    = eon_backup_policy.all_condition_types.name
       enabled = eon_backup_policy.all_condition_types.enabled
+    }
+    exclude_by_type_and_name = {
+      id      = eon_backup_policy.exclude_by_type_and_name.id
+      name    = eon_backup_policy.exclude_by_type_and_name.name
+      enabled = eon_backup_policy.exclude_by_type_and_name.enabled
     }
   }
 }
@@ -893,7 +1021,7 @@ Optional:
 Optional:
 
 - `environment` (Attributes) Environment condition (see [below for nested schema](#nestedatt--resource_selector--expression--environment))
-- `group` (Attributes) Group condition with logical operator and operands (see [below for nested schema](#nestedatt--resource_selector--expression--group))
+- `group` (Attributes) Group condition with logical operator and operands. Operands may nest further groups (AND/OR) up to 3 levels deep, matching the console resource selector. (see [below for nested schema](#nestedatt--resource_selector--expression--group))
 - `resource_type` (Attributes) Resource type condition (see [below for nested schema](#nestedatt--resource_selector--expression--resource_type))
 - `tag_key_values` (Attributes) Tag key-value pairs condition (see [below for nested schema](#nestedatt--resource_selector--expression--tag_key_values))
 - `tag_keys` (Attributes) Tag keys condition (see [below for nested schema](#nestedatt--resource_selector--expression--tag_keys))
@@ -912,7 +1040,7 @@ Required:
 
 Required:
 
-- `operands` (Attributes List) List of conditions (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands))
+- `operands` (Attributes List) List of conditions. Each operand may be a leaf condition or a nested group (AND/OR), matching the console resource selector. (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands))
 - `operator` (String) Logical operator: 'AND' or 'OR'
 
 <a id="nestedatt--resource_selector--expression--group--operands"></a>
@@ -925,6 +1053,7 @@ Optional:
 - `cloud_provider` (Attributes) Cloud provider condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--cloud_provider))
 - `data_classes` (Attributes) Data classes condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--data_classes))
 - `environment` (Attributes) Environment condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--environment))
+- `group` (Attributes) Nested group condition with logical operator and operands. Groups nest up to 3 levels deep. (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group))
 - `resource_group_name` (Attributes) Resource group name condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--resource_group_name))
 - `resource_id` (Attributes) Resource ID condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--resource_id))
 - `resource_name` (Attributes) Resource name condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--resource_name))
@@ -978,6 +1107,337 @@ Required:
 
 - `environments` (List of String) List of environments
 - `operator` (String) Operator: 'IN' or 'NOT_IN'
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group`
+
+Required:
+
+- `operands` (Attributes List) List of conditions (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands))
+- `operator` (String) Logical operator: 'AND' or 'OR'
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands`
+
+Optional:
+
+- `account_id` (Attributes) Account ID condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--account_id))
+- `apps` (Attributes) Apps condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--apps))
+- `cloud_provider` (Attributes) Cloud provider condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--cloud_provider))
+- `data_classes` (Attributes) Data classes condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--data_classes))
+- `environment` (Attributes) Environment condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--environment))
+- `group` (Attributes) Nested group condition with logical operator and operands. Groups nest up to 3 levels deep. (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--group))
+- `resource_group_name` (Attributes) Resource group name condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--resource_group_name))
+- `resource_id` (Attributes) Resource ID condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--resource_id))
+- `resource_name` (Attributes) Resource name condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--resource_name))
+- `resource_type` (Attributes) Resource type condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--resource_type))
+- `source_region` (Attributes) Source region condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--source_region))
+- `subnets` (Attributes) Subnets condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--subnets))
+- `tag_key_values` (Attributes) Tag key-value pairs condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--tag_key_values))
+- `tag_keys` (Attributes) Tag keys condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--tag_keys))
+- `vpc` (Attributes) VPC condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--vpc))
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--account_id"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.account_id`
+
+Required:
+
+- `account_ids` (List of String) List of account IDs
+- `operator` (String) Operator: 'IN' or 'NOT_IN'
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--apps"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.apps`
+
+Required:
+
+- `apps` (List of String) List of apps
+- `operator` (String) Operator: 'CONTAINS' or 'NOT_CONTAINS'
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--cloud_provider"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.cloud_provider`
+
+Required:
+
+- `cloud_providers` (List of String) List of cloud providers
+- `operator` (String) Operator: 'IN' or 'NOT_IN'
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--data_classes"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.data_classes`
+
+Required:
+
+- `data_classes` (List of String) List of data classes
+- `operator` (String) Operator: 'CONTAINS' or 'NOT_CONTAINS'
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--environment"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.environment`
+
+Required:
+
+- `environments` (List of String) List of environments
+- `operator` (String) Operator: 'IN' or 'NOT_IN'
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--group"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.group`
+
+Required:
+
+- `operands` (Attributes List) List of conditions (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--group--operands))
+- `operator` (String) Logical operator: 'AND' or 'OR'
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--group--operands"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.group.operands`
+
+Optional:
+
+- `account_id` (Attributes) Account ID condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--account_id))
+- `apps` (Attributes) Apps condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--apps))
+- `cloud_provider` (Attributes) Cloud provider condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--cloud_provider))
+- `data_classes` (Attributes) Data classes condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--data_classes))
+- `environment` (Attributes) Environment condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--environment))
+- `resource_group_name` (Attributes) Resource group name condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--resource_group_name))
+- `resource_id` (Attributes) Resource ID condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--resource_id))
+- `resource_name` (Attributes) Resource name condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--resource_name))
+- `resource_type` (Attributes) Resource type condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--resource_type))
+- `source_region` (Attributes) Source region condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--source_region))
+- `subnets` (Attributes) Subnets condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--subnets))
+- `tag_key_values` (Attributes) Tag key-value pairs condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--tag_key_values))
+- `tag_keys` (Attributes) Tag keys condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--tag_keys))
+- `vpc` (Attributes) VPC condition (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--vpc))
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--account_id"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.group.operands.account_id`
+
+Required:
+
+- `account_ids` (List of String) List of account IDs
+- `operator` (String) Operator: 'IN' or 'NOT_IN'
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--apps"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.group.operands.apps`
+
+Required:
+
+- `apps` (List of String) List of apps
+- `operator` (String) Operator: 'CONTAINS' or 'NOT_CONTAINS'
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--cloud_provider"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.group.operands.cloud_provider`
+
+Required:
+
+- `cloud_providers` (List of String) List of cloud providers
+- `operator` (String) Operator: 'IN' or 'NOT_IN'
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--data_classes"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.group.operands.data_classes`
+
+Required:
+
+- `data_classes` (List of String) List of data classes
+- `operator` (String) Operator: 'CONTAINS' or 'NOT_CONTAINS'
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--environment"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.group.operands.environment`
+
+Required:
+
+- `environments` (List of String) List of environments
+- `operator` (String) Operator: 'IN' or 'NOT_IN'
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--resource_group_name"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.group.operands.resource_group_name`
+
+Required:
+
+- `operator` (String) Operator: 'CONTAINS' or 'NOT_CONTAINS'
+- `resource_group_names` (List of String) List of resource group names
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--resource_id"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.group.operands.resource_id`
+
+Required:
+
+- `operator` (String) Operator: 'IN' or 'NOT_IN'
+- `resource_ids` (List of String) List of resource IDs
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--resource_name"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.group.operands.resource_name`
+
+Required:
+
+- `operator` (String) Operator: 'IN', 'NOT_IN', 'CONTAINS', 'NOT_CONTAINS', 'STARTS_WITH', 'NOT_STARTS_WITH', 'ENDS_WITH', or 'NOT_ENDS_WITH'
+- `resource_names` (List of String) List of resource names
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--resource_type"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.group.operands.resource_type`
+
+Required:
+
+- `operator` (String) Operator: 'IN' or 'NOT_IN'
+- `resource_types` (List of String) List of resource types
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--source_region"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.group.operands.source_region`
+
+Required:
+
+- `operator` (String) Operator: 'IN' or 'NOT_IN'
+- `source_regions` (List of String) List of source regions
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--subnets"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.group.operands.subnets`
+
+Required:
+
+- `operator` (String) Operator: 'CONTAINS' or 'NOT_CONTAINS'
+- `subnets` (List of String) List of subnets
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--tag_key_values"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.group.operands.tag_key_values`
+
+Required:
+
+- `operator` (String) Operator: 'IN' or 'NOT_IN'
+- `tag_key_values` (Attributes List) List of tag key-value pairs to match (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--tag_key_values--tag_key_values))
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--tag_key_values--tag_key_values"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.group.operands.tag_key_values.tag_key_values`
+
+Required:
+
+- `key` (String) Tag key
+- `value` (String) Tag value
+
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--tag_keys"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.group.operands.tag_keys`
+
+Required:
+
+- `operator` (String) Operator: 'IN' or 'NOT_IN'
+- `tag_keys` (List of String) List of tag keys to match
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--group--operands--vpc"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.group.operands.vpc`
+
+Required:
+
+- `operator` (String) Operator: 'IN' or 'NOT_IN'
+- `vpcs` (List of String) List of VPCs
+
+
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--resource_group_name"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.resource_group_name`
+
+Required:
+
+- `operator` (String) Operator: 'CONTAINS' or 'NOT_CONTAINS'
+- `resource_group_names` (List of String) List of resource group names
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--resource_id"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.resource_id`
+
+Required:
+
+- `operator` (String) Operator: 'IN' or 'NOT_IN'
+- `resource_ids` (List of String) List of resource IDs
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--resource_name"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.resource_name`
+
+Required:
+
+- `operator` (String) Operator: 'IN', 'NOT_IN', 'CONTAINS', 'NOT_CONTAINS', 'STARTS_WITH', 'NOT_STARTS_WITH', 'ENDS_WITH', or 'NOT_ENDS_WITH'
+- `resource_names` (List of String) List of resource names
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--resource_type"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.resource_type`
+
+Required:
+
+- `operator` (String) Operator: 'IN' or 'NOT_IN'
+- `resource_types` (List of String) List of resource types
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--source_region"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.source_region`
+
+Required:
+
+- `operator` (String) Operator: 'IN' or 'NOT_IN'
+- `source_regions` (List of String) List of source regions
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--subnets"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.subnets`
+
+Required:
+
+- `operator` (String) Operator: 'CONTAINS' or 'NOT_CONTAINS'
+- `subnets` (List of String) List of subnets
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--tag_key_values"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.tag_key_values`
+
+Required:
+
+- `operator` (String) Operator: 'IN' or 'NOT_IN'
+- `tag_key_values` (Attributes List) List of tag key-value pairs to match (see [below for nested schema](#nestedatt--resource_selector--expression--group--operands--group--operands--tag_key_values--tag_key_values))
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--tag_key_values--tag_key_values"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.tag_key_values.tag_key_values`
+
+Required:
+
+- `key` (String) Tag key
+- `value` (String) Tag value
+
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--tag_keys"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.tag_keys`
+
+Required:
+
+- `operator` (String) Operator: 'IN' or 'NOT_IN'
+- `tag_keys` (List of String) List of tag keys to match
+
+
+<a id="nestedatt--resource_selector--expression--group--operands--group--operands--vpc"></a>
+### Nested Schema for `resource_selector.expression.group.operands.group.operands.vpc`
+
+Required:
+
+- `operator` (String) Operator: 'IN' or 'NOT_IN'
+- `vpcs` (List of String) List of VPCs
+
+
 
 
 <a id="nestedatt--resource_selector--expression--group--operands--resource_group_name"></a>

--- a/docs/resources/backup_policy.md
+++ b/docs/resources/backup_policy.md
@@ -560,7 +560,7 @@ resource "eon_backup_policy" "exclude_by_type_and_name" {
                       {
                         resource_name = {
                           operator       = "NOT_CONTAINS"
-                          resource_names = ["db-test-users"]
+                          resource_names = ["example-rds-instance"]
                         }
                       }
                     ]
@@ -579,7 +579,7 @@ resource "eon_backup_policy" "exclude_by_type_and_name" {
                       {
                         resource_name = {
                           operator       = "NOT_CONTAINS"
-                          resource_names = ["lab-test-claims-events"]
+                          resource_names = ["example-dynamodb-table"]
                         }
                       }
                     ]

--- a/examples/resources/eon_backup_policy/resource.tf
+++ b/examples/resources/eon_backup_policy/resource.tf
@@ -545,7 +545,7 @@ resource "eon_backup_policy" "exclude_by_type_and_name" {
                       {
                         resource_name = {
                           operator       = "NOT_CONTAINS"
-                          resource_names = ["db-test-users"]
+                          resource_names = ["example-rds-instance"]
                         }
                       }
                     ]
@@ -564,7 +564,7 @@ resource "eon_backup_policy" "exclude_by_type_and_name" {
                       {
                         resource_name = {
                           operator       = "NOT_CONTAINS"
-                          resource_names = ["lab-test-claims-events"]
+                          resource_names = ["example-dynamodb-table"]
                         }
                       }
                     ]

--- a/examples/resources/eon_backup_policy/resource.tf
+++ b/examples/resources/eon_backup_policy/resource.tf
@@ -482,6 +482,124 @@ resource "eon_backup_policy" "all_condition_types" {
   }
 }
 
+# Example: Nested groups — exclude specific RDS and DynamoDB names (matches console AND → OR → AND)
+# Logic: account/region/tag/type filters AND (
+#   (type=RDS AND name does not contain exclude) OR
+#   (type=DynamoDB AND name does not contain exclude)
+# )
+resource "eon_backup_policy" "exclude_by_type_and_name" {
+  name    = "Standard Backup Excluding Test Resources"
+  enabled = true
+
+  resource_selector = {
+    resource_selection_mode = "CONDITIONAL"
+
+    expression = {
+      group = {
+        operator = "AND"
+        operands = [
+          {
+            account_id = {
+              operator    = "IN"
+              account_ids = ["123456789012"]
+            }
+          },
+          {
+            source_region = {
+              operator       = "IN"
+              source_regions = ["us-east-1"]
+            }
+          },
+          {
+            tag_key_values = {
+              operator = "CONTAINS_ANY_OF"
+              tag_key_values = [
+                {
+                  key   = "m_tier"
+                  value = "1"
+                }
+              ]
+            }
+          },
+          {
+            resource_type = {
+              operator       = "IN"
+              resource_types = ["AWS_RDS", "AWS_DYNAMO_DB"]
+            }
+          },
+          {
+            # Type-scoped name excludes: nested OR of (type AND name NOT_CONTAINS)
+            group = {
+              operator = "OR"
+              operands = [
+                {
+                  group = {
+                    operator = "AND"
+                    operands = [
+                      {
+                        resource_type = {
+                          operator       = "IN"
+                          resource_types = ["AWS_RDS"]
+                        }
+                      },
+                      {
+                        resource_name = {
+                          operator       = "NOT_CONTAINS"
+                          resource_names = ["db-test-users"]
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  group = {
+                    operator = "AND"
+                    operands = [
+                      {
+                        resource_type = {
+                          operator       = "IN"
+                          resource_types = ["AWS_DYNAMO_DB"]
+                        }
+                      },
+                      {
+                        resource_name = {
+                          operator       = "NOT_CONTAINS"
+                          resource_names = ["lab-test-claims-events"]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+
+  backup_plan = {
+    backup_policy_type = "STANDARD"
+    standard_plan = {
+      schedule_timezone = "RESOURCE"
+      backup_schedules = [
+        {
+          vault_id       = "e19a6ad1-6a97-49a1-b7c9-9620977ea018"
+          retention_days = 30
+          schedule_config = {
+            frequency = "DAILY"
+            daily_config = {
+              time_of_day_hour     = 2
+              time_of_day_minutes  = 0
+              start_window_minutes = 240
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
 # Output examples
 output "daily_backup_policy_id" {
   description = "ID of the daily backup policy"
@@ -526,6 +644,11 @@ output "conditional_backup_policy_id" {
 output "all_condition_types_policy_id" {
   description = "ID of the policy demonstrating all condition types"
   value       = eon_backup_policy.all_condition_types.id
+}
+
+output "exclude_by_type_and_name_policy_id" {
+  description = "ID of the nested-group exclude-by-type-and-name policy"
+  value       = eon_backup_policy.exclude_by_type_and_name.id
 }
 
 output "backup_policies_summary" {
@@ -575,6 +698,11 @@ output "backup_policies_summary" {
       id      = eon_backup_policy.all_condition_types.id
       name    = eon_backup_policy.all_condition_types.name
       enabled = eon_backup_policy.all_condition_types.enabled
+    }
+    exclude_by_type_and_name = {
+      id      = eon_backup_policy.exclude_by_type_and_name.id
+      name    = eon_backup_policy.exclude_by_type_and_name.name
+      enabled = eon_backup_policy.exclude_by_type_and_name.enabled
     }
   }
 }

--- a/internal/provider/backup_policy_expression.go
+++ b/internal/provider/backup_policy_expression.go
@@ -1,0 +1,267 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Nested group conditions are unrolled into the schema, so nesting depth is fixed up front.
+// Depth 3 covers the console pattern: top AND → nested OR → nested AND with leaf conditions.
+const backupPolicyMaxNestedGroupDepth = 3
+
+// backupPolicyOperandLeafAttributes is every leaf condition an operand may carry.
+func backupPolicyOperandLeafAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"resource_type": schema.SingleNestedAttribute{
+			MarkdownDescription: "Resource type condition",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"operator": schema.StringAttribute{
+					MarkdownDescription: "Operator: 'IN' or 'NOT_IN'",
+					Required:            true,
+				},
+				"resource_types": schema.ListAttribute{
+					MarkdownDescription: "List of resource types",
+					ElementType:         types.StringType,
+					Required:            true,
+				},
+			},
+		},
+		"environment": schema.SingleNestedAttribute{
+			MarkdownDescription: "Environment condition",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"operator": schema.StringAttribute{
+					MarkdownDescription: "Operator: 'IN' or 'NOT_IN'",
+					Required:            true,
+				},
+				"environments": schema.ListAttribute{
+					MarkdownDescription: "List of environments",
+					ElementType:         types.StringType,
+					Required:            true,
+				},
+			},
+		},
+		"tag_keys": schema.SingleNestedAttribute{
+			MarkdownDescription: "Tag keys condition",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"operator": schema.StringAttribute{
+					MarkdownDescription: "Operator: 'IN' or 'NOT_IN'",
+					Required:            true,
+				},
+				"tag_keys": schema.ListAttribute{
+					MarkdownDescription: "List of tag keys to match",
+					ElementType:         types.StringType,
+					Required:            true,
+				},
+			},
+		},
+		"tag_key_values": schema.SingleNestedAttribute{
+			MarkdownDescription: "Tag key-value pairs condition",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"operator": schema.StringAttribute{
+					MarkdownDescription: "Operator: 'IN' or 'NOT_IN'",
+					Required:            true,
+				},
+				"tag_key_values": schema.ListNestedAttribute{
+					MarkdownDescription: "List of tag key-value pairs to match",
+					Required:            true,
+					NestedObject: schema.NestedAttributeObject{
+						Attributes: map[string]schema.Attribute{
+							"key": schema.StringAttribute{
+								MarkdownDescription: "Tag key",
+								Required:            true,
+							},
+							"value": schema.StringAttribute{
+								MarkdownDescription: "Tag value",
+								Required:            true,
+							},
+						},
+					},
+				},
+			},
+		},
+		"data_classes": schema.SingleNestedAttribute{
+			MarkdownDescription: "Data classes condition",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"operator": schema.StringAttribute{
+					MarkdownDescription: "Operator: 'CONTAINS' or 'NOT_CONTAINS'",
+					Required:            true,
+				},
+				"data_classes": schema.ListAttribute{
+					MarkdownDescription: "List of data classes",
+					ElementType:         types.StringType,
+					Required:            true,
+				},
+			},
+		},
+		"apps": schema.SingleNestedAttribute{
+			MarkdownDescription: "Apps condition",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"operator": schema.StringAttribute{
+					MarkdownDescription: "Operator: 'CONTAINS' or 'NOT_CONTAINS'",
+					Required:            true,
+				},
+				"apps": schema.ListAttribute{
+					MarkdownDescription: "List of apps",
+					ElementType:         types.StringType,
+					Required:            true,
+				},
+			},
+		},
+		"cloud_provider": schema.SingleNestedAttribute{
+			MarkdownDescription: "Cloud provider condition",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"operator": schema.StringAttribute{
+					MarkdownDescription: "Operator: 'IN' or 'NOT_IN'",
+					Required:            true,
+				},
+				"cloud_providers": schema.ListAttribute{
+					MarkdownDescription: "List of cloud providers",
+					ElementType:         types.StringType,
+					Required:            true,
+				},
+			},
+		},
+		"account_id": schema.SingleNestedAttribute{
+			MarkdownDescription: "Account ID condition",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"operator": schema.StringAttribute{
+					MarkdownDescription: "Operator: 'IN' or 'NOT_IN'",
+					Required:            true,
+				},
+				"account_ids": schema.ListAttribute{
+					MarkdownDescription: "List of account IDs",
+					ElementType:         types.StringType,
+					Required:            true,
+				},
+			},
+		},
+		"source_region": schema.SingleNestedAttribute{
+			MarkdownDescription: "Source region condition",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"operator": schema.StringAttribute{
+					MarkdownDescription: "Operator: 'IN' or 'NOT_IN'",
+					Required:            true,
+				},
+				"source_regions": schema.ListAttribute{
+					MarkdownDescription: "List of source regions",
+					ElementType:         types.StringType,
+					Required:            true,
+				},
+			},
+		},
+		"vpc": schema.SingleNestedAttribute{
+			MarkdownDescription: "VPC condition",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"operator": schema.StringAttribute{
+					MarkdownDescription: "Operator: 'IN' or 'NOT_IN'",
+					Required:            true,
+				},
+				"vpcs": schema.ListAttribute{
+					MarkdownDescription: "List of VPCs",
+					ElementType:         types.StringType,
+					Required:            true,
+				},
+			},
+		},
+		"subnets": schema.SingleNestedAttribute{
+			MarkdownDescription: "Subnets condition",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"operator": schema.StringAttribute{
+					MarkdownDescription: "Operator: 'CONTAINS' or 'NOT_CONTAINS'",
+					Required:            true,
+				},
+				"subnets": schema.ListAttribute{
+					MarkdownDescription: "List of subnets",
+					ElementType:         types.StringType,
+					Required:            true,
+				},
+			},
+		},
+		"resource_group_name": schema.SingleNestedAttribute{
+			MarkdownDescription: "Resource group name condition",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"operator": schema.StringAttribute{
+					MarkdownDescription: "Operator: 'CONTAINS' or 'NOT_CONTAINS'",
+					Required:            true,
+				},
+				"resource_group_names": schema.ListAttribute{
+					MarkdownDescription: "List of resource group names",
+					ElementType:         types.StringType,
+					Required:            true,
+				},
+			},
+		},
+		"resource_name": schema.SingleNestedAttribute{
+			MarkdownDescription: "Resource name condition",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"operator": schema.StringAttribute{
+					MarkdownDescription: "Operator: 'IN', 'NOT_IN', 'CONTAINS', 'NOT_CONTAINS', 'STARTS_WITH', 'NOT_STARTS_WITH', 'ENDS_WITH', or 'NOT_ENDS_WITH'",
+					Required:            true,
+				},
+				"resource_names": schema.ListAttribute{
+					MarkdownDescription: "List of resource names",
+					ElementType:         types.StringType,
+					Required:            true,
+				},
+			},
+		},
+		"resource_id": schema.SingleNestedAttribute{
+			MarkdownDescription: "Resource ID condition",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"operator": schema.StringAttribute{
+					MarkdownDescription: "Operator: 'IN' or 'NOT_IN'",
+					Required:            true,
+				},
+				"resource_ids": schema.ListAttribute{
+					MarkdownDescription: "List of resource IDs",
+					ElementType:         types.StringType,
+					Required:            true,
+				},
+			},
+		},
+	}
+}
+
+// backupPolicyOperandAttributes returns leaf conditions plus nested group when depth allows it.
+func backupPolicyOperandAttributes(depth int) map[string]schema.Attribute {
+	attrs := backupPolicyOperandLeafAttributes()
+	if depth > 1 {
+		attrs["group"] = schema.SingleNestedAttribute{
+			MarkdownDescription: fmt.Sprintf(
+				"Nested group condition with logical operator and operands. Groups nest up to %d levels deep.",
+				backupPolicyMaxNestedGroupDepth,
+			),
+			Optional: true,
+			Attributes: map[string]schema.Attribute{
+				"operator": schema.StringAttribute{
+					MarkdownDescription: "Logical operator: 'AND' or 'OR'",
+					Required:            true,
+				},
+				"operands": schema.ListNestedAttribute{
+					MarkdownDescription: "List of conditions",
+					Required:            true,
+					NestedObject: schema.NestedAttributeObject{
+						Attributes: backupPolicyOperandAttributes(depth - 1),
+					},
+				},
+			},
+		}
+	}
+	return attrs
+}

--- a/internal/provider/backup_policy_flatten.go
+++ b/internal/provider/backup_policy_flatten.go
@@ -464,7 +464,7 @@ func flattenOperand(
 		"resource_type": true, "environment": true, "tag_keys": true, "tag_key_values": true,
 		"data_classes": true, "apps": true, "cloud_provider": true, "account_id": true,
 		"source_region": true, "vpc": true, "subnets": true, "resource_group_name": true,
-		"resource_name": true, "resource_id": true,
+		"resource_name": true, "resource_id": true, "group": true,
 	}
 	if unrepresentable := unrepresentableConditions(operand, supported); len(unrepresentable) > 0 {
 		diags.AddError(
@@ -537,6 +537,18 @@ func flattenOperand(
 		flattened, conditionDiags := flattenTagKeyValuesCondition(t, "tag_key_values", *condition)
 		diags.Append(conditionDiags...)
 		present["tag_key_values"] = flattened
+	}
+
+	if condition := operand.Group.Get(); condition != nil {
+		groupType, typeDiags := nestedObjectType(t, "group")
+		diags.Append(typeDiags...)
+		if diags.HasError() {
+			return types.ObjectNull(t.AttrTypes), diags
+		}
+
+		flattened, groupDiags := flattenGroupCondition(ctx, groupType, *condition, types.ObjectNull(groupType.AttrTypes))
+		diags.Append(groupDiags...)
+		present["group"] = flattened
 	}
 
 	if diags.HasError() {

--- a/internal/provider/backup_policy_flatten_test.go
+++ b/internal/provider/backup_policy_flatten_test.go
@@ -136,7 +136,7 @@ func TestFlattenBackupPolicy_NestedGroupExpression(t *testing.T) {
 
 	rdsName := externalEonSdkAPI.NewBackupPolicyExpression()
 	rdsName.SetResourceName(*externalEonSdkAPI.NewResourceNameCondition(
-		externalEonSdkAPI.StringOperators("NOT_CONTAINS"), []string{"db-test-users"}))
+		externalEonSdkAPI.StringOperators("NOT_CONTAINS"), []string{"example-rds-instance"}))
 
 	rdsAnd := externalEonSdkAPI.NewBackupPolicyExpression()
 	rdsAnd.SetGroup(*externalEonSdkAPI.NewBackupPolicyGroupCondition(
@@ -149,7 +149,7 @@ func TestFlattenBackupPolicy_NestedGroupExpression(t *testing.T) {
 
 	dynamoName := externalEonSdkAPI.NewBackupPolicyExpression()
 	dynamoName.SetResourceName(*externalEonSdkAPI.NewResourceNameCondition(
-		externalEonSdkAPI.StringOperators("NOT_CONTAINS"), []string{"lab-test-claims-events"}))
+		externalEonSdkAPI.StringOperators("NOT_CONTAINS"), []string{"example-dynamodb-table"}))
 
 	dynamoAnd := externalEonSdkAPI.NewBackupPolicyExpression()
 	dynamoAnd.SetGroup(*externalEonSdkAPI.NewBackupPolicyGroupCondition(
@@ -196,7 +196,7 @@ func TestFlattenBackupPolicy_NestedGroupExpression(t *testing.T) {
 		nestedValue(t, nameOperand, "resource_name", "operator"))
 	names, ok := nestedValue(t, nameOperand, "resource_name", "resource_names").(types.List)
 	require.True(t, ok)
-	assert.Equal(t, []attr.Value{types.StringValue("db-test-users")}, names.Elements())
+	assert.Equal(t, []attr.Value{types.StringValue("example-rds-instance")}, names.Elements())
 }
 
 func TestBackupPolicyOperandSchemaAllowsNestedGroup(t *testing.T) {

--- a/internal/provider/backup_policy_flatten_test.go
+++ b/internal/provider/backup_policy_flatten_test.go
@@ -6,6 +6,8 @@ import (
 
 	externalEonSdkAPI "github.com/eon-io/eon-sdk-go"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -120,6 +122,111 @@ func TestFlattenBackupPolicy_GroupExpression(t *testing.T) {
 	names, ok := nestedValue(t, data.ResourceSelector, "expression", "group", "operands", "resource_name", "resource_names").(types.List)
 	require.True(t, ok)
 	assert.Equal(t, []attr.Value{types.StringValue("prod-")}, names.Elements())
+}
+
+// TestFlattenBackupPolicy_NestedGroupExpression covers the console pattern: top AND → nested OR →
+// nested AND with type+name leaf conditions (type-scoped name excludes).
+func TestFlattenBackupPolicy_NestedGroupExpression(t *testing.T) {
+	t.Parallel()
+
+	rdsType := externalEonSdkAPI.NewBackupPolicyExpression()
+	rdsType.SetResourceType(*externalEonSdkAPI.NewResourceTypeCondition(
+		externalEonSdkAPI.ScalarOperators("IN"),
+		[]externalEonSdkAPI.ResourceType{externalEonSdkAPI.AWS_RDS}))
+
+	rdsName := externalEonSdkAPI.NewBackupPolicyExpression()
+	rdsName.SetResourceName(*externalEonSdkAPI.NewResourceNameCondition(
+		externalEonSdkAPI.StringOperators("NOT_CONTAINS"), []string{"db-test-users"}))
+
+	rdsAnd := externalEonSdkAPI.NewBackupPolicyExpression()
+	rdsAnd.SetGroup(*externalEonSdkAPI.NewBackupPolicyGroupCondition(
+		externalEonSdkAPI.AND_OPERATOR, []externalEonSdkAPI.BackupPolicyExpression{*rdsType, *rdsName}))
+
+	dynamoType := externalEonSdkAPI.NewBackupPolicyExpression()
+	dynamoType.SetResourceType(*externalEonSdkAPI.NewResourceTypeCondition(
+		externalEonSdkAPI.ScalarOperators("IN"),
+		[]externalEonSdkAPI.ResourceType{externalEonSdkAPI.AWS_DYNAMO_DB}))
+
+	dynamoName := externalEonSdkAPI.NewBackupPolicyExpression()
+	dynamoName.SetResourceName(*externalEonSdkAPI.NewResourceNameCondition(
+		externalEonSdkAPI.StringOperators("NOT_CONTAINS"), []string{"lab-test-claims-events"}))
+
+	dynamoAnd := externalEonSdkAPI.NewBackupPolicyExpression()
+	dynamoAnd.SetGroup(*externalEonSdkAPI.NewBackupPolicyGroupCondition(
+		externalEonSdkAPI.AND_OPERATOR, []externalEonSdkAPI.BackupPolicyExpression{*dynamoType, *dynamoName}))
+
+	excludeOr := externalEonSdkAPI.NewBackupPolicyExpression()
+	excludeOr.SetGroup(*externalEonSdkAPI.NewBackupPolicyGroupCondition(
+		externalEonSdkAPI.OR_OPERATOR, []externalEonSdkAPI.BackupPolicyExpression{*rdsAnd, *dynamoAnd}))
+
+	region := externalEonSdkAPI.NewBackupPolicyExpression()
+	region.SetSourceRegion(*externalEonSdkAPI.NewRegionCondition(
+		externalEonSdkAPI.ScalarOperators("IN"), []string{"us-east-1"}))
+
+	topAnd := externalEonSdkAPI.NewBackupPolicyExpression()
+	topAnd.SetGroup(*externalEonSdkAPI.NewBackupPolicyGroupCondition(
+		externalEonSdkAPI.AND_OPERATOR, []externalEonSdkAPI.BackupPolicyExpression{*region, *excludeOr}))
+
+	policy := standardPolicy(dailyScheduleConfig(1, 0))
+	policy.ResourceSelector.ResourceSelectionMode = externalEonSdkAPI.RESOURCE_SELECTOR_MODE_CONDITIONAL
+	policy.ResourceSelector.SetExpression(*topAnd)
+
+	data := BackupPolicyResourceModel{}
+	diags := flattenBackupPolicy(context.Background(), policy, policySchemaType(t), &data)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags.Errors())
+
+	assert.Equal(t, types.StringValue("AND"), nestedValue(t, data.ResourceSelector, "expression", "group", "operator"))
+
+	operands := nestedValue(t, data.ResourceSelector, "expression", "group", "operands").(types.List)
+	require.Len(t, operands.Elements(), 2)
+
+	orOperand := operands.Elements()[1].(types.Object)
+	assert.Equal(t, types.StringValue("OR"), nestedValue(t, orOperand, "group", "operator"))
+
+	orOperands := nestedValue(t, orOperand, "group", "operands").(types.List)
+	require.Len(t, orOperands.Elements(), 2)
+
+	rdsBranch := orOperands.Elements()[0].(types.Object)
+	assert.Equal(t, types.StringValue("AND"), nestedValue(t, rdsBranch, "group", "operator"))
+
+	rdsOperands := nestedValue(t, rdsBranch, "group", "operands").(types.List)
+	require.Len(t, rdsOperands.Elements(), 2)
+	nameOperand := rdsOperands.Elements()[1].(types.Object)
+	assert.Equal(t, types.StringValue("NOT_CONTAINS"),
+		nestedValue(t, nameOperand, "resource_name", "operator"))
+	names, ok := nestedValue(t, nameOperand, "resource_name", "resource_names").(types.List)
+	require.True(t, ok)
+	assert.Equal(t, []attr.Value{types.StringValue("db-test-users")}, names.Elements())
+}
+
+func TestBackupPolicyOperandSchemaAllowsNestedGroup(t *testing.T) {
+	t.Parallel()
+
+	policyResource := &BackupPolicyResource{}
+	var resp resource.SchemaResponse
+	policyResource.Schema(context.Background(), resource.SchemaRequest{}, &resp)
+	require.False(t, resp.Diagnostics.HasError())
+
+	expression := resp.Schema.Attributes["resource_selector"].(schema.SingleNestedAttribute).
+		Attributes["expression"].(schema.SingleNestedAttribute)
+	group := expression.Attributes["group"].(schema.SingleNestedAttribute)
+	operand := group.Attributes["operands"].(schema.ListNestedAttribute).NestedObject.Attributes
+	assert.Contains(t, operand, "group", "operands must accept a nested group")
+
+	nestedOperand := operand["group"].(schema.SingleNestedAttribute).
+		Attributes["operands"].(schema.ListNestedAttribute).NestedObject.Attributes
+	assert.Contains(t, nestedOperand, "group", "second nesting level must still accept a group")
+
+	innermost := nestedOperand["group"].(schema.SingleNestedAttribute).
+		Attributes["operands"].(schema.ListNestedAttribute).NestedObject.Attributes
+	assert.NotContains(t, innermost, "group", "nesting must stop at the configured depth")
+}
+
+func TestNormalizeResourceNameOperator(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "NOT_CONTAINS", normalizeResourceNameOperator("DOES_NOT_CONTAIN"))
+	assert.Equal(t, "NOT_CONTAINS", normalizeResourceNameOperator("NOT_CONTAINS"))
+	assert.Equal(t, "IN", normalizeResourceNameOperator("IN"))
 }
 
 // TestFlattenBackupPolicy_RejectsUnrepresentableCondition guards the other half of drift detection:

--- a/internal/provider/resource_backup_policy.go
+++ b/internal/provider/resource_backup_policy.go
@@ -159,6 +159,7 @@ type OperandModel struct {
 	ResourceGroupName types.Object `tfsdk:"resource_group_name"`
 	ResourceName      types.Object `tfsdk:"resource_name"`
 	ResourceId        types.Object `tfsdk:"resource_id"`
+	Group             types.Object `tfsdk:"group"`
 }
 
 type ResourceTypeConditionModel struct {
@@ -351,7 +352,7 @@ func (r *BackupPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 								},
 							},
 							"group": schema.SingleNestedAttribute{
-								MarkdownDescription: "Group condition with logical operator and operands",
+								MarkdownDescription: "Group condition with logical operator and operands. Operands may nest further groups (AND/OR) up to 3 levels deep, matching the console resource selector.",
 								Optional:            true,
 								Attributes: map[string]schema.Attribute{
 									"operator": schema.StringAttribute{
@@ -359,232 +360,10 @@ func (r *BackupPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 										Required:            true,
 									},
 									"operands": schema.ListNestedAttribute{
-										MarkdownDescription: "List of conditions",
+										MarkdownDescription: "List of conditions. Each operand may be a leaf condition or a nested group (AND/OR), matching the console resource selector.",
 										Required:            true,
 										NestedObject: schema.NestedAttributeObject{
-											Attributes: map[string]schema.Attribute{
-												"resource_type": schema.SingleNestedAttribute{
-													MarkdownDescription: "Resource type condition",
-													Optional:            true,
-													Attributes: map[string]schema.Attribute{
-														"operator": schema.StringAttribute{
-															MarkdownDescription: "Operator: 'IN' or 'NOT_IN'",
-															Required:            true,
-														},
-														"resource_types": schema.ListAttribute{
-															MarkdownDescription: "List of resource types",
-															ElementType:         types.StringType,
-															Required:            true,
-														},
-													},
-												},
-												"environment": schema.SingleNestedAttribute{
-													MarkdownDescription: "Environment condition",
-													Optional:            true,
-													Attributes: map[string]schema.Attribute{
-														"operator": schema.StringAttribute{
-															MarkdownDescription: "Operator: 'IN' or 'NOT_IN'",
-															Required:            true,
-														},
-														"environments": schema.ListAttribute{
-															MarkdownDescription: "List of environments",
-															ElementType:         types.StringType,
-															Required:            true,
-														},
-													},
-												},
-												"tag_keys": schema.SingleNestedAttribute{
-													MarkdownDescription: "Tag keys condition",
-													Optional:            true,
-													Attributes: map[string]schema.Attribute{
-														"operator": schema.StringAttribute{
-															MarkdownDescription: "Operator: 'IN' or 'NOT_IN'",
-															Required:            true,
-														},
-														"tag_keys": schema.ListAttribute{
-															MarkdownDescription: "List of tag keys to match",
-															ElementType:         types.StringType,
-															Required:            true,
-														},
-													},
-												},
-												"tag_key_values": schema.SingleNestedAttribute{
-													MarkdownDescription: "Tag key-value pairs condition",
-													Optional:            true,
-													Attributes: map[string]schema.Attribute{
-														"operator": schema.StringAttribute{
-															MarkdownDescription: "Operator: 'IN' or 'NOT_IN'",
-															Required:            true,
-														},
-														"tag_key_values": schema.ListNestedAttribute{
-															MarkdownDescription: "List of tag key-value pairs to match",
-															Required:            true,
-															NestedObject: schema.NestedAttributeObject{
-																Attributes: map[string]schema.Attribute{
-																	"key": schema.StringAttribute{
-																		MarkdownDescription: "Tag key",
-																		Required:            true,
-																	},
-																	"value": schema.StringAttribute{
-																		MarkdownDescription: "Tag value",
-																		Required:            true,
-																	},
-																},
-															},
-														},
-													},
-												},
-												"data_classes": schema.SingleNestedAttribute{
-													MarkdownDescription: "Data classes condition",
-													Optional:            true,
-													Attributes: map[string]schema.Attribute{
-														"operator": schema.StringAttribute{
-															MarkdownDescription: "Operator: 'CONTAINS' or 'NOT_CONTAINS'",
-															Required:            true,
-														},
-														"data_classes": schema.ListAttribute{
-															MarkdownDescription: "List of data classes",
-															ElementType:         types.StringType,
-															Required:            true,
-														},
-													},
-												},
-												"apps": schema.SingleNestedAttribute{
-													MarkdownDescription: "Apps condition",
-													Optional:            true,
-													Attributes: map[string]schema.Attribute{
-														"operator": schema.StringAttribute{
-															MarkdownDescription: "Operator: 'CONTAINS' or 'NOT_CONTAINS'",
-															Required:            true,
-														},
-														"apps": schema.ListAttribute{
-															MarkdownDescription: "List of apps",
-															ElementType:         types.StringType,
-															Required:            true,
-														},
-													},
-												},
-												"cloud_provider": schema.SingleNestedAttribute{
-													MarkdownDescription: "Cloud provider condition",
-													Optional:            true,
-													Attributes: map[string]schema.Attribute{
-														"operator": schema.StringAttribute{
-															MarkdownDescription: "Operator: 'IN' or 'NOT_IN'",
-															Required:            true,
-														},
-														"cloud_providers": schema.ListAttribute{
-															MarkdownDescription: "List of cloud providers",
-															ElementType:         types.StringType,
-															Required:            true,
-														},
-													},
-												},
-												"account_id": schema.SingleNestedAttribute{
-													MarkdownDescription: "Account ID condition",
-													Optional:            true,
-													Attributes: map[string]schema.Attribute{
-														"operator": schema.StringAttribute{
-															MarkdownDescription: "Operator: 'IN' or 'NOT_IN'",
-															Required:            true,
-														},
-														"account_ids": schema.ListAttribute{
-															MarkdownDescription: "List of account IDs",
-															ElementType:         types.StringType,
-															Required:            true,
-														},
-													},
-												},
-												"source_region": schema.SingleNestedAttribute{
-													MarkdownDescription: "Source region condition",
-													Optional:            true,
-													Attributes: map[string]schema.Attribute{
-														"operator": schema.StringAttribute{
-															MarkdownDescription: "Operator: 'IN' or 'NOT_IN'",
-															Required:            true,
-														},
-														"source_regions": schema.ListAttribute{
-															MarkdownDescription: "List of source regions",
-															ElementType:         types.StringType,
-															Required:            true,
-														},
-													},
-												},
-												"vpc": schema.SingleNestedAttribute{
-													MarkdownDescription: "VPC condition",
-													Optional:            true,
-													Attributes: map[string]schema.Attribute{
-														"operator": schema.StringAttribute{
-															MarkdownDescription: "Operator: 'IN' or 'NOT_IN'",
-															Required:            true,
-														},
-														"vpcs": schema.ListAttribute{
-															MarkdownDescription: "List of VPCs",
-															ElementType:         types.StringType,
-															Required:            true,
-														},
-													},
-												},
-												"subnets": schema.SingleNestedAttribute{
-													MarkdownDescription: "Subnets condition",
-													Optional:            true,
-													Attributes: map[string]schema.Attribute{
-														"operator": schema.StringAttribute{
-															MarkdownDescription: "Operator: 'CONTAINS' or 'NOT_CONTAINS'",
-															Required:            true,
-														},
-														"subnets": schema.ListAttribute{
-															MarkdownDescription: "List of subnets",
-															ElementType:         types.StringType,
-															Required:            true,
-														},
-													},
-												},
-												"resource_group_name": schema.SingleNestedAttribute{
-													MarkdownDescription: "Resource group name condition",
-													Optional:            true,
-													Attributes: map[string]schema.Attribute{
-														"operator": schema.StringAttribute{
-															MarkdownDescription: "Operator: 'CONTAINS' or 'NOT_CONTAINS'",
-															Required:            true,
-														},
-														"resource_group_names": schema.ListAttribute{
-															MarkdownDescription: "List of resource group names",
-															ElementType:         types.StringType,
-															Required:            true,
-														},
-													},
-												},
-												"resource_name": schema.SingleNestedAttribute{
-													MarkdownDescription: "Resource name condition",
-													Optional:            true,
-													Attributes: map[string]schema.Attribute{
-														"operator": schema.StringAttribute{
-															MarkdownDescription: "Operator: 'IN', 'NOT_IN', 'CONTAINS', 'NOT_CONTAINS', 'STARTS_WITH', 'NOT_STARTS_WITH', 'ENDS_WITH', or 'NOT_ENDS_WITH'",
-															Required:            true,
-														},
-														"resource_names": schema.ListAttribute{
-															MarkdownDescription: "List of resource names",
-															ElementType:         types.StringType,
-															Required:            true,
-														},
-													},
-												},
-												"resource_id": schema.SingleNestedAttribute{
-													MarkdownDescription: "Resource ID condition",
-													Optional:            true,
-													Attributes: map[string]schema.Attribute{
-														"operator": schema.StringAttribute{
-															MarkdownDescription: "Operator: 'IN' or 'NOT_IN'",
-															Required:            true,
-														},
-														"resource_ids": schema.ListAttribute{
-															MarkdownDescription: "List of resource IDs",
-															ElementType:         types.StringType,
-															Required:            true,
-														},
-													},
-												},
-											},
+											Attributes: backupPolicyOperandAttributes(backupPolicyMaxNestedGroupDepth),
 										},
 									},
 								},
@@ -2235,313 +2014,345 @@ func createBackupPolicyExpression(ctx context.Context, data *ResourceSelectorMod
 	}
 
 	if groupObj, exists := expressionAttrs["group"]; exists && !groupObj.IsNull() {
-		var groupCondition GroupConditionModel
-		diags := groupObj.(types.Object).As(ctx, &groupCondition, basetypes.ObjectAsOptions{})
-		if diags.HasError() {
-			tflog.Error(ctx, "Failed to parse group condition", map[string]interface{}{
-				"error": diags.Errors(),
-			})
-			return nil, fmt.Errorf("failed to parse group condition")
+		groupConditionApi, err := createBackupPolicyGroupCondition(ctx, groupObj.(types.Object))
+		if err != nil {
+			return nil, err
 		}
-
-		var operands []OperandModel
-		diags = groupCondition.Operands.ElementsAs(ctx, &operands, false)
-		if diags.HasError() {
-			return nil, fmt.Errorf("failed to parse operands")
-		}
-
-		var expressions []externalEonSdkAPI.BackupPolicyExpression
-		for _, operand := range operands {
-			operandExpr := externalEonSdkAPI.NewBackupPolicyExpression()
-
-			if !operand.ResourceType.IsNull() {
-				var resourceTypeCondition ResourceTypeConditionModel
-				diags := operand.ResourceType.As(ctx, &resourceTypeCondition, basetypes.ObjectAsOptions{})
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse resource type condition in operand")
-				}
-
-				var resourceTypes []string
-				diags = resourceTypeCondition.ResourceTypes.ElementsAs(ctx, &resourceTypes, false)
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse resource types in operand")
-				}
-
-				var resourceTypeEnums []externalEonSdkAPI.ResourceType
-				for _, rt := range resourceTypes {
-					resourceTypeEnums = append(resourceTypeEnums, externalEonSdkAPI.ResourceType(rt))
-				}
-
-				operator := externalEonSdkAPI.ScalarOperators(resourceTypeCondition.Operator.ValueString())
-				resourceTypeConditionApi := externalEonSdkAPI.NewResourceTypeCondition(operator, resourceTypeEnums)
-				operandExpr.SetResourceType(*resourceTypeConditionApi)
-			}
-
-			if !operand.Environment.IsNull() {
-				var envCondition EnvironmentConditionModel
-				diags := operand.Environment.As(ctx, &envCondition, basetypes.ObjectAsOptions{})
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse environment condition in operand")
-				}
-
-				var environments []string
-				diags = envCondition.Environments.ElementsAs(ctx, &environments, false)
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse environments in operand")
-				}
-
-				var environmentEnums []externalEonSdkAPI.Environment
-				for _, env := range environments {
-					environmentEnums = append(environmentEnums, externalEonSdkAPI.Environment(env))
-				}
-
-				operator := externalEonSdkAPI.ScalarOperators(envCondition.Operator.ValueString())
-				envConditionApi := externalEonSdkAPI.NewEnvironmentCondition(operator, environmentEnums)
-				operandExpr.SetEnvironment(*envConditionApi)
-			}
-
-			if !operand.TagKeys.IsNull() {
-				var tagKeysCondition TagKeysConditionModel
-				diags := operand.TagKeys.As(ctx, &tagKeysCondition, basetypes.ObjectAsOptions{})
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse tag keys condition in operand")
-				}
-
-				var tagKeys []string
-				diags = tagKeysCondition.TagKeys.ElementsAs(ctx, &tagKeys, false)
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse tag keys in operand")
-				}
-
-				operator := externalEonSdkAPI.ListOperators(tagKeysCondition.Operator.ValueString())
-				tagKeysConditionApi := externalEonSdkAPI.NewTagKeysCondition(operator, tagKeys)
-				operandExpr.SetTagKeys(*tagKeysConditionApi)
-			}
-
-			if !operand.TagKeyValues.IsNull() {
-				var tagKeyValuesCondition TagKeyValuesConditionModel
-				diags := operand.TagKeyValues.As(ctx, &tagKeyValuesCondition, basetypes.ObjectAsOptions{})
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse tag key-values condition in operand")
-				}
-
-				var tagKeyValues []TagKeyValueModel
-				diags = tagKeyValuesCondition.TagKeyValues.ElementsAs(ctx, &tagKeyValues, false)
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse tag key-values in operand")
-				}
-
-				var tagKeyValueEnums []externalEonSdkAPI.TagKeyValue
-				for _, kv := range tagKeyValues {
-					tagKeyValue := externalEonSdkAPI.NewTagKeyValue(kv.Key.ValueString())
-					tagKeyValue.SetValue(kv.Value.ValueString())
-					tagKeyValueEnums = append(tagKeyValueEnums, *tagKeyValue)
-				}
-
-				operator := externalEonSdkAPI.ListOperators(tagKeyValuesCondition.Operator.ValueString())
-				tagKeyValuesConditionApi := externalEonSdkAPI.NewTagKeyValuesCondition(operator, tagKeyValueEnums)
-				operandExpr.SetTagKeyValues(*tagKeyValuesConditionApi)
-			}
-
-			if !operand.DataClasses.IsNull() {
-				var dataClassesCondition DataClassesConditionModel
-				diags := operand.DataClasses.As(ctx, &dataClassesCondition, basetypes.ObjectAsOptions{})
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse data_classes condition in operand")
-				}
-
-				var dataClasses []string
-				diags = dataClassesCondition.DataClasses.ElementsAs(ctx, &dataClasses, false)
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse data_classes list in operand")
-				}
-
-				operator := externalEonSdkAPI.ListOperators(dataClassesCondition.Operator.ValueString())
-				dataClassesConditionApi := externalEonSdkAPI.NewDataClassesCondition(operator, dataClasses)
-				operandExpr.SetDataClasses(*dataClassesConditionApi)
-			}
-
-			if !operand.Apps.IsNull() {
-				var appsCondition AppsConditionModel
-				diags := operand.Apps.As(ctx, &appsCondition, basetypes.ObjectAsOptions{})
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse apps condition in operand")
-				}
-
-				var apps []string
-				diags = appsCondition.Apps.ElementsAs(ctx, &apps, false)
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse apps list in operand")
-				}
-
-				operator := externalEonSdkAPI.ListOperators(appsCondition.Operator.ValueString())
-				appsConditionApi := externalEonSdkAPI.NewAppsCondition(operator, apps)
-				operandExpr.SetApps(*appsConditionApi)
-			}
-
-			if !operand.CloudProvider.IsNull() {
-				var cloudProviderCondition CloudProviderConditionModel
-				diags := operand.CloudProvider.As(ctx, &cloudProviderCondition, basetypes.ObjectAsOptions{})
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse cloud_provider condition in operand")
-				}
-
-				var cloudProviders []string
-				diags = cloudProviderCondition.CloudProviders.ElementsAs(ctx, &cloudProviders, false)
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse cloud_providers list in operand")
-				}
-
-				var providerEnums []externalEonSdkAPI.Provider
-				for _, cp := range cloudProviders {
-					providerEnums = append(providerEnums, externalEonSdkAPI.Provider(cp))
-				}
-
-				operator := externalEonSdkAPI.ScalarOperators(cloudProviderCondition.Operator.ValueString())
-				cloudProviderConditionApi := externalEonSdkAPI.NewCloudProviderCondition(operator, providerEnums)
-				operandExpr.SetCloudProvider(*cloudProviderConditionApi)
-			}
-
-			if !operand.AccountId.IsNull() {
-				var accountIdCondition AccountIdConditionModel
-				diags := operand.AccountId.As(ctx, &accountIdCondition, basetypes.ObjectAsOptions{})
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse account_id condition in operand")
-				}
-
-				var accountIds []string
-				diags = accountIdCondition.AccountIds.ElementsAs(ctx, &accountIds, false)
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse account_ids list in operand")
-				}
-
-				operator := externalEonSdkAPI.ScalarOperators(accountIdCondition.Operator.ValueString())
-				accountIdConditionApi := externalEonSdkAPI.NewAccountIdCondition(operator, accountIds)
-				operandExpr.SetAccountId(*accountIdConditionApi)
-			}
-
-			if !operand.SourceRegion.IsNull() {
-				var sourceRegionCondition SourceRegionConditionModel
-				diags := operand.SourceRegion.As(ctx, &sourceRegionCondition, basetypes.ObjectAsOptions{})
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse source_region condition in operand")
-				}
-
-				var sourceRegions []string
-				diags = sourceRegionCondition.SourceRegions.ElementsAs(ctx, &sourceRegions, false)
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse source_regions list in operand")
-				}
-
-				operator := externalEonSdkAPI.ScalarOperators(sourceRegionCondition.Operator.ValueString())
-				sourceRegionConditionApi := externalEonSdkAPI.NewRegionCondition(operator, sourceRegions)
-				operandExpr.SetSourceRegion(*sourceRegionConditionApi)
-			}
-
-			if !operand.Vpc.IsNull() {
-				var vpcCondition VpcConditionModel
-				diags := operand.Vpc.As(ctx, &vpcCondition, basetypes.ObjectAsOptions{})
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse vpc condition in operand")
-				}
-
-				var vpcs []string
-				diags = vpcCondition.Vpcs.ElementsAs(ctx, &vpcs, false)
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse vpcs list in operand")
-				}
-
-				operator := externalEonSdkAPI.ScalarOperators(vpcCondition.Operator.ValueString())
-				vpcConditionApi := externalEonSdkAPI.NewVpcCondition(operator, vpcs)
-				operandExpr.SetVpc(*vpcConditionApi)
-			}
-
-			if !operand.Subnets.IsNull() {
-				var subnetsCondition SubnetsConditionModel
-				diags := operand.Subnets.As(ctx, &subnetsCondition, basetypes.ObjectAsOptions{})
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse subnets condition in operand")
-				}
-
-				var subnets []string
-				diags = subnetsCondition.Subnets.ElementsAs(ctx, &subnets, false)
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse subnets list in operand")
-				}
-
-				operator := externalEonSdkAPI.ListOperators(subnetsCondition.Operator.ValueString())
-				subnetsConditionApi := externalEonSdkAPI.NewSubnetsCondition(operator, subnets)
-				operandExpr.SetSubnets(*subnetsConditionApi)
-			}
-
-			if !operand.ResourceGroupName.IsNull() {
-				var resourceGroupNameCondition ResourceGroupNameConditionModel
-				diags := operand.ResourceGroupName.As(ctx, &resourceGroupNameCondition, basetypes.ObjectAsOptions{})
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse resource_group_name condition in operand")
-				}
-
-				var resourceGroupNames []string
-				diags = resourceGroupNameCondition.ResourceGroupNames.ElementsAs(ctx, &resourceGroupNames, false)
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse resource_group_names list in operand")
-				}
-
-				operator := externalEonSdkAPI.ScalarOperators(resourceGroupNameCondition.Operator.ValueString())
-				resourceGroupNameConditionApi := externalEonSdkAPI.NewResourceGroupNameCondition(operator, resourceGroupNames)
-				operandExpr.SetResourceGroupName(*resourceGroupNameConditionApi)
-			}
-
-			if !operand.ResourceName.IsNull() {
-				var resourceNameCondition ResourceNameConditionModel
-				diags := operand.ResourceName.As(ctx, &resourceNameCondition, basetypes.ObjectAsOptions{})
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse resource_name condition in operand")
-				}
-
-				var resourceNames []string
-				diags = resourceNameCondition.ResourceNames.ElementsAs(ctx, &resourceNames, false)
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse resource_names list in operand")
-				}
-
-				operator := externalEonSdkAPI.StringOperators(resourceNameCondition.Operator.ValueString())
-				resourceNameConditionApi := externalEonSdkAPI.NewResourceNameCondition(operator, resourceNames)
-				operandExpr.SetResourceName(*resourceNameConditionApi)
-			}
-
-			if !operand.ResourceId.IsNull() {
-				var resourceIdCondition ResourceIdConditionModel
-				diags := operand.ResourceId.As(ctx, &resourceIdCondition, basetypes.ObjectAsOptions{})
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse resource_id condition in operand")
-				}
-
-				var resourceIds []string
-				diags = resourceIdCondition.ResourceIds.ElementsAs(ctx, &resourceIds, false)
-				if diags.HasError() {
-					return nil, fmt.Errorf("failed to parse resource_ids list in operand")
-				}
-
-				operator := externalEonSdkAPI.ScalarOperators(resourceIdCondition.Operator.ValueString())
-				resourceIdConditionApi := externalEonSdkAPI.NewResourceIdCondition(operator, resourceIds)
-				operandExpr.SetResourceId(*resourceIdConditionApi)
-			}
-
-			expressions = append(expressions, *operandExpr)
-		}
-
-		logicalOperator := externalEonSdkAPI.LogicalOperator(groupCondition.Operator.ValueString())
-		groupConditionApi := externalEonSdkAPI.NewBackupPolicyGroupCondition(logicalOperator, expressions)
 		expr.SetGroup(*groupConditionApi)
 
 		tflog.Debug(ctx, "Successfully created group condition", map[string]interface{}{
-			"operator":       groupCondition.Operator.ValueString(),
-			"operands_count": len(operands),
+			"operator":       string(groupConditionApi.Operator),
+			"operands_count": len(groupConditionApi.Operands),
 		})
 
 		return expr, nil
 	}
 
 	return nil, fmt.Errorf("expression must have at least one condition (environment, resource_type, tag_key_values, tag_keys, group, etc.)")
+}
+
+func createBackupPolicyGroupCondition(ctx context.Context, groupObj types.Object) (*externalEonSdkAPI.BackupPolicyGroupCondition, error) {
+	var groupCondition GroupConditionModel
+	diags := groupObj.As(ctx, &groupCondition, basetypes.ObjectAsOptions{})
+	if diags.HasError() {
+		tflog.Error(ctx, "Failed to parse group condition", map[string]interface{}{
+			"error": diags.Errors(),
+		})
+		return nil, fmt.Errorf("failed to parse group condition")
+	}
+
+	var operands []OperandModel
+	diags = groupCondition.Operands.ElementsAs(ctx, &operands, false)
+	if diags.HasError() {
+		return nil, fmt.Errorf("failed to parse operands")
+	}
+
+	expressions := make([]externalEonSdkAPI.BackupPolicyExpression, 0, len(operands))
+	for _, operand := range operands {
+		operandExpr, err := createBackupPolicyOperandExpression(ctx, operand)
+		if err != nil {
+			return nil, err
+		}
+		expressions = append(expressions, *operandExpr)
+	}
+
+	logicalOperator := externalEonSdkAPI.LogicalOperator(groupCondition.Operator.ValueString())
+	return externalEonSdkAPI.NewBackupPolicyGroupCondition(logicalOperator, expressions), nil
+}
+
+func createBackupPolicyOperandExpression(ctx context.Context, operand OperandModel) (*externalEonSdkAPI.BackupPolicyExpression, error) {
+	operandExpr := externalEonSdkAPI.NewBackupPolicyExpression()
+
+	if !operand.Group.IsNull() && !operand.Group.IsUnknown() {
+		groupConditionApi, err := createBackupPolicyGroupCondition(ctx, operand.Group)
+		if err != nil {
+			return nil, err
+		}
+		operandExpr.SetGroup(*groupConditionApi)
+		return operandExpr, nil
+	}
+
+	if !operand.ResourceType.IsNull() {
+		var resourceTypeCondition ResourceTypeConditionModel
+		diags := operand.ResourceType.As(ctx, &resourceTypeCondition, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse resource type condition in operand")
+		}
+
+		var resourceTypes []string
+		diags = resourceTypeCondition.ResourceTypes.ElementsAs(ctx, &resourceTypes, false)
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse resource types in operand")
+		}
+
+		var resourceTypeEnums []externalEonSdkAPI.ResourceType
+		for _, rt := range resourceTypes {
+			resourceTypeEnums = append(resourceTypeEnums, externalEonSdkAPI.ResourceType(rt))
+		}
+
+		operator := externalEonSdkAPI.ScalarOperators(resourceTypeCondition.Operator.ValueString())
+		resourceTypeConditionApi := externalEonSdkAPI.NewResourceTypeCondition(operator, resourceTypeEnums)
+		operandExpr.SetResourceType(*resourceTypeConditionApi)
+	}
+
+	if !operand.Environment.IsNull() {
+		var envCondition EnvironmentConditionModel
+		diags := operand.Environment.As(ctx, &envCondition, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse environment condition in operand")
+		}
+
+		var environments []string
+		diags = envCondition.Environments.ElementsAs(ctx, &environments, false)
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse environments in operand")
+		}
+
+		var environmentEnums []externalEonSdkAPI.Environment
+		for _, env := range environments {
+			environmentEnums = append(environmentEnums, externalEonSdkAPI.Environment(env))
+		}
+
+		operator := externalEonSdkAPI.ScalarOperators(envCondition.Operator.ValueString())
+		envConditionApi := externalEonSdkAPI.NewEnvironmentCondition(operator, environmentEnums)
+		operandExpr.SetEnvironment(*envConditionApi)
+	}
+
+	if !operand.TagKeys.IsNull() {
+		var tagKeysCondition TagKeysConditionModel
+		diags := operand.TagKeys.As(ctx, &tagKeysCondition, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse tag keys condition in operand")
+		}
+
+		var tagKeys []string
+		diags = tagKeysCondition.TagKeys.ElementsAs(ctx, &tagKeys, false)
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse tag keys in operand")
+		}
+
+		operator := externalEonSdkAPI.ListOperators(tagKeysCondition.Operator.ValueString())
+		tagKeysConditionApi := externalEonSdkAPI.NewTagKeysCondition(operator, tagKeys)
+		operandExpr.SetTagKeys(*tagKeysConditionApi)
+	}
+
+	if !operand.TagKeyValues.IsNull() {
+		var tagKeyValuesCondition TagKeyValuesConditionModel
+		diags := operand.TagKeyValues.As(ctx, &tagKeyValuesCondition, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse tag key-values condition in operand")
+		}
+
+		var tagKeyValues []TagKeyValueModel
+		diags = tagKeyValuesCondition.TagKeyValues.ElementsAs(ctx, &tagKeyValues, false)
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse tag key-values in operand")
+		}
+
+		var tagKeyValueEnums []externalEonSdkAPI.TagKeyValue
+		for _, kv := range tagKeyValues {
+			tagKeyValue := externalEonSdkAPI.NewTagKeyValue(kv.Key.ValueString())
+			tagKeyValue.SetValue(kv.Value.ValueString())
+			tagKeyValueEnums = append(tagKeyValueEnums, *tagKeyValue)
+		}
+
+		operator := externalEonSdkAPI.ListOperators(tagKeyValuesCondition.Operator.ValueString())
+		tagKeyValuesConditionApi := externalEonSdkAPI.NewTagKeyValuesCondition(operator, tagKeyValueEnums)
+		operandExpr.SetTagKeyValues(*tagKeyValuesConditionApi)
+	}
+
+	if !operand.DataClasses.IsNull() {
+		var dataClassesCondition DataClassesConditionModel
+		diags := operand.DataClasses.As(ctx, &dataClassesCondition, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse data_classes condition in operand")
+		}
+
+		var dataClasses []string
+		diags = dataClassesCondition.DataClasses.ElementsAs(ctx, &dataClasses, false)
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse data_classes list in operand")
+		}
+
+		operator := externalEonSdkAPI.ListOperators(dataClassesCondition.Operator.ValueString())
+		dataClassesConditionApi := externalEonSdkAPI.NewDataClassesCondition(operator, dataClasses)
+		operandExpr.SetDataClasses(*dataClassesConditionApi)
+	}
+
+	if !operand.Apps.IsNull() {
+		var appsCondition AppsConditionModel
+		diags := operand.Apps.As(ctx, &appsCondition, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse apps condition in operand")
+		}
+
+		var apps []string
+		diags = appsCondition.Apps.ElementsAs(ctx, &apps, false)
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse apps list in operand")
+		}
+
+		operator := externalEonSdkAPI.ListOperators(appsCondition.Operator.ValueString())
+		appsConditionApi := externalEonSdkAPI.NewAppsCondition(operator, apps)
+		operandExpr.SetApps(*appsConditionApi)
+	}
+
+	if !operand.CloudProvider.IsNull() {
+		var cloudProviderCondition CloudProviderConditionModel
+		diags := operand.CloudProvider.As(ctx, &cloudProviderCondition, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse cloud_provider condition in operand")
+		}
+
+		var cloudProviders []string
+		diags = cloudProviderCondition.CloudProviders.ElementsAs(ctx, &cloudProviders, false)
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse cloud_providers list in operand")
+		}
+
+		var providerEnums []externalEonSdkAPI.Provider
+		for _, cp := range cloudProviders {
+			providerEnums = append(providerEnums, externalEonSdkAPI.Provider(cp))
+		}
+
+		operator := externalEonSdkAPI.ScalarOperators(cloudProviderCondition.Operator.ValueString())
+		cloudProviderConditionApi := externalEonSdkAPI.NewCloudProviderCondition(operator, providerEnums)
+		operandExpr.SetCloudProvider(*cloudProviderConditionApi)
+	}
+
+	if !operand.AccountId.IsNull() {
+		var accountIdCondition AccountIdConditionModel
+		diags := operand.AccountId.As(ctx, &accountIdCondition, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse account_id condition in operand")
+		}
+
+		var accountIds []string
+		diags = accountIdCondition.AccountIds.ElementsAs(ctx, &accountIds, false)
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse account_ids list in operand")
+		}
+
+		operator := externalEonSdkAPI.ScalarOperators(accountIdCondition.Operator.ValueString())
+		accountIdConditionApi := externalEonSdkAPI.NewAccountIdCondition(operator, accountIds)
+		operandExpr.SetAccountId(*accountIdConditionApi)
+	}
+
+	if !operand.SourceRegion.IsNull() {
+		var sourceRegionCondition SourceRegionConditionModel
+		diags := operand.SourceRegion.As(ctx, &sourceRegionCondition, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse source_region condition in operand")
+		}
+
+		var sourceRegions []string
+		diags = sourceRegionCondition.SourceRegions.ElementsAs(ctx, &sourceRegions, false)
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse source_regions list in operand")
+		}
+
+		operator := externalEonSdkAPI.ScalarOperators(sourceRegionCondition.Operator.ValueString())
+		sourceRegionConditionApi := externalEonSdkAPI.NewRegionCondition(operator, sourceRegions)
+		operandExpr.SetSourceRegion(*sourceRegionConditionApi)
+	}
+
+	if !operand.Vpc.IsNull() {
+		var vpcCondition VpcConditionModel
+		diags := operand.Vpc.As(ctx, &vpcCondition, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse vpc condition in operand")
+		}
+
+		var vpcs []string
+		diags = vpcCondition.Vpcs.ElementsAs(ctx, &vpcs, false)
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse vpcs list in operand")
+		}
+
+		operator := externalEonSdkAPI.ScalarOperators(vpcCondition.Operator.ValueString())
+		vpcConditionApi := externalEonSdkAPI.NewVpcCondition(operator, vpcs)
+		operandExpr.SetVpc(*vpcConditionApi)
+	}
+
+	if !operand.Subnets.IsNull() {
+		var subnetsCondition SubnetsConditionModel
+		diags := operand.Subnets.As(ctx, &subnetsCondition, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse subnets condition in operand")
+		}
+
+		var subnets []string
+		diags = subnetsCondition.Subnets.ElementsAs(ctx, &subnets, false)
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse subnets list in operand")
+		}
+
+		operator := externalEonSdkAPI.ListOperators(subnetsCondition.Operator.ValueString())
+		subnetsConditionApi := externalEonSdkAPI.NewSubnetsCondition(operator, subnets)
+		operandExpr.SetSubnets(*subnetsConditionApi)
+	}
+
+	if !operand.ResourceGroupName.IsNull() {
+		var resourceGroupNameCondition ResourceGroupNameConditionModel
+		diags := operand.ResourceGroupName.As(ctx, &resourceGroupNameCondition, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse resource_group_name condition in operand")
+		}
+
+		var resourceGroupNames []string
+		diags = resourceGroupNameCondition.ResourceGroupNames.ElementsAs(ctx, &resourceGroupNames, false)
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse resource_group_names list in operand")
+		}
+
+		operator := externalEonSdkAPI.ScalarOperators(resourceGroupNameCondition.Operator.ValueString())
+		resourceGroupNameConditionApi := externalEonSdkAPI.NewResourceGroupNameCondition(operator, resourceGroupNames)
+		operandExpr.SetResourceGroupName(*resourceGroupNameConditionApi)
+	}
+
+	if !operand.ResourceName.IsNull() {
+		var resourceNameCondition ResourceNameConditionModel
+		diags := operand.ResourceName.As(ctx, &resourceNameCondition, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse resource_name condition in operand")
+		}
+
+		var resourceNames []string
+		diags = resourceNameCondition.ResourceNames.ElementsAs(ctx, &resourceNames, false)
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse resource_names list in operand")
+		}
+
+		operator := externalEonSdkAPI.StringOperators(normalizeResourceNameOperator(resourceNameCondition.Operator.ValueString()))
+		resourceNameConditionApi := externalEonSdkAPI.NewResourceNameCondition(operator, resourceNames)
+		operandExpr.SetResourceName(*resourceNameConditionApi)
+	}
+
+	if !operand.ResourceId.IsNull() {
+		var resourceIdCondition ResourceIdConditionModel
+		diags := operand.ResourceId.As(ctx, &resourceIdCondition, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse resource_id condition in operand")
+		}
+
+		var resourceIds []string
+		diags = resourceIdCondition.ResourceIds.ElementsAs(ctx, &resourceIds, false)
+		if diags.HasError() {
+			return nil, fmt.Errorf("failed to parse resource_ids list in operand")
+		}
+
+		operator := externalEonSdkAPI.ScalarOperators(resourceIdCondition.Operator.ValueString())
+		resourceIdConditionApi := externalEonSdkAPI.NewResourceIdCondition(operator, resourceIds)
+		operandExpr.SetResourceId(*resourceIdConditionApi)
+	}
+
+	return operandExpr, nil
+}
+
+// normalizeResourceNameOperator accepts the console-style alias DOES_NOT_CONTAIN.
+func normalizeResourceNameOperator(operator string) string {
+	if operator == "DOES_NOT_CONTAIN" {
+		return "NOT_CONTAINS"
+	}
+	return operator
 }

--- a/internal/provider/resource_backup_policy.go
+++ b/internal/provider/resource_backup_policy.go
@@ -2032,39 +2032,47 @@ func createBackupPolicyExpression(ctx context.Context, data *ResourceSelectorMod
 }
 
 func createBackupPolicyGroupCondition(ctx context.Context, groupObj types.Object) (*externalEonSdkAPI.BackupPolicyGroupCondition, error) {
-	var groupCondition GroupConditionModel
-	diags := groupObj.As(ctx, &groupCondition, basetypes.ObjectAsOptions{})
-	if diags.HasError() {
-		tflog.Error(ctx, "Failed to parse group condition", map[string]interface{}{
-			"error": diags.Errors(),
-		})
-		return nil, fmt.Errorf("failed to parse group condition")
+	// Walk attributes directly so nested group depths with different operand schemas
+	// (innermost has no `group` attr) still parse — ElementsAs into OperandModel fails there.
+	attrs := groupObj.Attributes()
+
+	opAttr, ok := attrs["operator"]
+	if !ok || opAttr.IsNull() || opAttr.IsUnknown() {
+		return nil, fmt.Errorf("group operator is required")
+	}
+	operator := opAttr.(types.String).ValueString()
+
+	operandsAttr, ok := attrs["operands"]
+	if !ok || operandsAttr.IsNull() || operandsAttr.IsUnknown() {
+		return nil, fmt.Errorf("group operands are required")
+	}
+	operandsList, ok := operandsAttr.(types.List)
+	if !ok {
+		return nil, fmt.Errorf("group operands must be a list")
 	}
 
-	var operands []OperandModel
-	diags = groupCondition.Operands.ElementsAs(ctx, &operands, false)
-	if diags.HasError() {
-		return nil, fmt.Errorf("failed to parse operands")
-	}
-
-	expressions := make([]externalEonSdkAPI.BackupPolicyExpression, 0, len(operands))
-	for _, operand := range operands {
-		operandExpr, err := createBackupPolicyOperandExpression(ctx, operand)
+	expressions := make([]externalEonSdkAPI.BackupPolicyExpression, 0, len(operandsList.Elements()))
+	for i, elem := range operandsList.Elements() {
+		operandObj, ok := elem.(types.Object)
+		if !ok {
+			return nil, fmt.Errorf("operand %d is not an object", i)
+		}
+		operandExpr, err := createBackupPolicyOperandExpression(ctx, operandObj)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("operand %d: %w", i, err)
 		}
 		expressions = append(expressions, *operandExpr)
 	}
 
-	logicalOperator := externalEonSdkAPI.LogicalOperator(groupCondition.Operator.ValueString())
-	return externalEonSdkAPI.NewBackupPolicyGroupCondition(logicalOperator, expressions), nil
+	return externalEonSdkAPI.NewBackupPolicyGroupCondition(externalEonSdkAPI.LogicalOperator(operator), expressions), nil
 }
 
-func createBackupPolicyOperandExpression(ctx context.Context, operand OperandModel) (*externalEonSdkAPI.BackupPolicyExpression, error) {
+func createBackupPolicyOperandExpression(ctx context.Context, operandObj types.Object) (*externalEonSdkAPI.BackupPolicyExpression, error) {
+	attrs := operandObj.Attributes()
 	operandExpr := externalEonSdkAPI.NewBackupPolicyExpression()
 
-	if !operand.Group.IsNull() && !operand.Group.IsUnknown() {
-		groupConditionApi, err := createBackupPolicyGroupCondition(ctx, operand.Group)
+	if groupVal, ok := attrs["group"]; ok && !groupVal.IsNull() && !groupVal.IsUnknown() {
+		groupConditionApi, err := createBackupPolicyGroupCondition(ctx, groupVal.(types.Object))
 		if err != nil {
 			return nil, err
 		}
@@ -2072,9 +2080,9 @@ func createBackupPolicyOperandExpression(ctx context.Context, operand OperandMod
 		return operandExpr, nil
 	}
 
-	if !operand.ResourceType.IsNull() {
+	if obj, ok := optionalObjectAttr(attrs, "resource_type"); ok {
 		var resourceTypeCondition ResourceTypeConditionModel
-		diags := operand.ResourceType.As(ctx, &resourceTypeCondition, basetypes.ObjectAsOptions{})
+		diags := obj.As(ctx, &resourceTypeCondition, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
 			return nil, fmt.Errorf("failed to parse resource type condition in operand")
 		}
@@ -2095,9 +2103,9 @@ func createBackupPolicyOperandExpression(ctx context.Context, operand OperandMod
 		operandExpr.SetResourceType(*resourceTypeConditionApi)
 	}
 
-	if !operand.Environment.IsNull() {
+	if obj, ok := optionalObjectAttr(attrs, "environment"); ok {
 		var envCondition EnvironmentConditionModel
-		diags := operand.Environment.As(ctx, &envCondition, basetypes.ObjectAsOptions{})
+		diags := obj.As(ctx, &envCondition, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
 			return nil, fmt.Errorf("failed to parse environment condition in operand")
 		}
@@ -2118,9 +2126,9 @@ func createBackupPolicyOperandExpression(ctx context.Context, operand OperandMod
 		operandExpr.SetEnvironment(*envConditionApi)
 	}
 
-	if !operand.TagKeys.IsNull() {
+	if obj, ok := optionalObjectAttr(attrs, "tag_keys"); ok {
 		var tagKeysCondition TagKeysConditionModel
-		diags := operand.TagKeys.As(ctx, &tagKeysCondition, basetypes.ObjectAsOptions{})
+		diags := obj.As(ctx, &tagKeysCondition, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
 			return nil, fmt.Errorf("failed to parse tag keys condition in operand")
 		}
@@ -2136,9 +2144,9 @@ func createBackupPolicyOperandExpression(ctx context.Context, operand OperandMod
 		operandExpr.SetTagKeys(*tagKeysConditionApi)
 	}
 
-	if !operand.TagKeyValues.IsNull() {
+	if obj, ok := optionalObjectAttr(attrs, "tag_key_values"); ok {
 		var tagKeyValuesCondition TagKeyValuesConditionModel
-		diags := operand.TagKeyValues.As(ctx, &tagKeyValuesCondition, basetypes.ObjectAsOptions{})
+		diags := obj.As(ctx, &tagKeyValuesCondition, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
 			return nil, fmt.Errorf("failed to parse tag key-values condition in operand")
 		}
@@ -2161,9 +2169,9 @@ func createBackupPolicyOperandExpression(ctx context.Context, operand OperandMod
 		operandExpr.SetTagKeyValues(*tagKeyValuesConditionApi)
 	}
 
-	if !operand.DataClasses.IsNull() {
+	if obj, ok := optionalObjectAttr(attrs, "data_classes"); ok {
 		var dataClassesCondition DataClassesConditionModel
-		diags := operand.DataClasses.As(ctx, &dataClassesCondition, basetypes.ObjectAsOptions{})
+		diags := obj.As(ctx, &dataClassesCondition, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
 			return nil, fmt.Errorf("failed to parse data_classes condition in operand")
 		}
@@ -2179,9 +2187,9 @@ func createBackupPolicyOperandExpression(ctx context.Context, operand OperandMod
 		operandExpr.SetDataClasses(*dataClassesConditionApi)
 	}
 
-	if !operand.Apps.IsNull() {
+	if obj, ok := optionalObjectAttr(attrs, "apps"); ok {
 		var appsCondition AppsConditionModel
-		diags := operand.Apps.As(ctx, &appsCondition, basetypes.ObjectAsOptions{})
+		diags := obj.As(ctx, &appsCondition, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
 			return nil, fmt.Errorf("failed to parse apps condition in operand")
 		}
@@ -2197,9 +2205,9 @@ func createBackupPolicyOperandExpression(ctx context.Context, operand OperandMod
 		operandExpr.SetApps(*appsConditionApi)
 	}
 
-	if !operand.CloudProvider.IsNull() {
+	if obj, ok := optionalObjectAttr(attrs, "cloud_provider"); ok {
 		var cloudProviderCondition CloudProviderConditionModel
-		diags := operand.CloudProvider.As(ctx, &cloudProviderCondition, basetypes.ObjectAsOptions{})
+		diags := obj.As(ctx, &cloudProviderCondition, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
 			return nil, fmt.Errorf("failed to parse cloud_provider condition in operand")
 		}
@@ -2220,9 +2228,9 @@ func createBackupPolicyOperandExpression(ctx context.Context, operand OperandMod
 		operandExpr.SetCloudProvider(*cloudProviderConditionApi)
 	}
 
-	if !operand.AccountId.IsNull() {
+	if obj, ok := optionalObjectAttr(attrs, "account_id"); ok {
 		var accountIdCondition AccountIdConditionModel
-		diags := operand.AccountId.As(ctx, &accountIdCondition, basetypes.ObjectAsOptions{})
+		diags := obj.As(ctx, &accountIdCondition, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
 			return nil, fmt.Errorf("failed to parse account_id condition in operand")
 		}
@@ -2238,9 +2246,9 @@ func createBackupPolicyOperandExpression(ctx context.Context, operand OperandMod
 		operandExpr.SetAccountId(*accountIdConditionApi)
 	}
 
-	if !operand.SourceRegion.IsNull() {
+	if obj, ok := optionalObjectAttr(attrs, "source_region"); ok {
 		var sourceRegionCondition SourceRegionConditionModel
-		diags := operand.SourceRegion.As(ctx, &sourceRegionCondition, basetypes.ObjectAsOptions{})
+		diags := obj.As(ctx, &sourceRegionCondition, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
 			return nil, fmt.Errorf("failed to parse source_region condition in operand")
 		}
@@ -2256,9 +2264,9 @@ func createBackupPolicyOperandExpression(ctx context.Context, operand OperandMod
 		operandExpr.SetSourceRegion(*sourceRegionConditionApi)
 	}
 
-	if !operand.Vpc.IsNull() {
+	if obj, ok := optionalObjectAttr(attrs, "vpc"); ok {
 		var vpcCondition VpcConditionModel
-		diags := operand.Vpc.As(ctx, &vpcCondition, basetypes.ObjectAsOptions{})
+		diags := obj.As(ctx, &vpcCondition, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
 			return nil, fmt.Errorf("failed to parse vpc condition in operand")
 		}
@@ -2274,9 +2282,9 @@ func createBackupPolicyOperandExpression(ctx context.Context, operand OperandMod
 		operandExpr.SetVpc(*vpcConditionApi)
 	}
 
-	if !operand.Subnets.IsNull() {
+	if obj, ok := optionalObjectAttr(attrs, "subnets"); ok {
 		var subnetsCondition SubnetsConditionModel
-		diags := operand.Subnets.As(ctx, &subnetsCondition, basetypes.ObjectAsOptions{})
+		diags := obj.As(ctx, &subnetsCondition, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
 			return nil, fmt.Errorf("failed to parse subnets condition in operand")
 		}
@@ -2292,9 +2300,9 @@ func createBackupPolicyOperandExpression(ctx context.Context, operand OperandMod
 		operandExpr.SetSubnets(*subnetsConditionApi)
 	}
 
-	if !operand.ResourceGroupName.IsNull() {
+	if obj, ok := optionalObjectAttr(attrs, "resource_group_name"); ok {
 		var resourceGroupNameCondition ResourceGroupNameConditionModel
-		diags := operand.ResourceGroupName.As(ctx, &resourceGroupNameCondition, basetypes.ObjectAsOptions{})
+		diags := obj.As(ctx, &resourceGroupNameCondition, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
 			return nil, fmt.Errorf("failed to parse resource_group_name condition in operand")
 		}
@@ -2310,9 +2318,9 @@ func createBackupPolicyOperandExpression(ctx context.Context, operand OperandMod
 		operandExpr.SetResourceGroupName(*resourceGroupNameConditionApi)
 	}
 
-	if !operand.ResourceName.IsNull() {
+	if obj, ok := optionalObjectAttr(attrs, "resource_name"); ok {
 		var resourceNameCondition ResourceNameConditionModel
-		diags := operand.ResourceName.As(ctx, &resourceNameCondition, basetypes.ObjectAsOptions{})
+		diags := obj.As(ctx, &resourceNameCondition, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
 			return nil, fmt.Errorf("failed to parse resource_name condition in operand")
 		}
@@ -2328,9 +2336,9 @@ func createBackupPolicyOperandExpression(ctx context.Context, operand OperandMod
 		operandExpr.SetResourceName(*resourceNameConditionApi)
 	}
 
-	if !operand.ResourceId.IsNull() {
+	if obj, ok := optionalObjectAttr(attrs, "resource_id"); ok {
 		var resourceIdCondition ResourceIdConditionModel
-		diags := operand.ResourceId.As(ctx, &resourceIdCondition, basetypes.ObjectAsOptions{})
+		diags := obj.As(ctx, &resourceIdCondition, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
 			return nil, fmt.Errorf("failed to parse resource_id condition in operand")
 		}
@@ -2347,6 +2355,15 @@ func createBackupPolicyOperandExpression(ctx context.Context, operand OperandMod
 	}
 
 	return operandExpr, nil
+}
+
+func optionalObjectAttr(attrs map[string]attr.Value, name string) (types.Object, bool) {
+	v, ok := attrs[name]
+	if !ok || v.IsNull() || v.IsUnknown() {
+		return types.Object{}, false
+	}
+	obj, ok := v.(types.Object)
+	return obj, ok
 }
 
 // normalizeResourceNameOperator accepts the console-style alias DOES_NOT_CONTAIN.

--- a/internal/provider/resource_backup_policy_nested_groups_acc_test.go
+++ b/internal/provider/resource_backup_policy_nested_groups_acc_test.go
@@ -38,9 +38,9 @@ func TestAccBackupPolicyNestedGroups(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "resource_selector.expression.group.operands.2.group.operands.0.group.operator", "AND"),
 					resource.TestCheckResourceAttr(resourceName, "resource_selector.expression.group.operands.2.group.operands.0.group.operands.0.resource_type.resource_types.0", "AWS_RDS"),
 					resource.TestCheckResourceAttr(resourceName, "resource_selector.expression.group.operands.2.group.operands.0.group.operands.1.resource_name.operator", "NOT_CONTAINS"),
-					resource.TestCheckResourceAttr(resourceName, "resource_selector.expression.group.operands.2.group.operands.0.group.operands.1.resource_name.resource_names.0", "db-test-users"),
+					resource.TestCheckResourceAttr(resourceName, "resource_selector.expression.group.operands.2.group.operands.0.group.operands.1.resource_name.resource_names.0", "example-rds-instance"),
 					resource.TestCheckResourceAttr(resourceName, "resource_selector.expression.group.operands.2.group.operands.1.group.operands.0.resource_type.resource_types.0", "AWS_DYNAMO_DB"),
-					resource.TestCheckResourceAttr(resourceName, "resource_selector.expression.group.operands.2.group.operands.1.group.operands.1.resource_name.resource_names.0", "lab-test-claims-events"),
+					resource.TestCheckResourceAttr(resourceName, "resource_selector.expression.group.operands.2.group.operands.1.group.operands.1.resource_name.resource_names.0", "example-dynamodb-table"),
 				),
 			},
 			{
@@ -95,7 +95,7 @@ resource "eon_backup_policy" "test" {
                       {
                         resource_name = {
                           operator       = "NOT_CONTAINS"
-                          resource_names = ["db-test-users"]
+                          resource_names = ["example-rds-instance"]
                         }
                       }
                     ]
@@ -114,7 +114,7 @@ resource "eon_backup_policy" "test" {
                       {
                         resource_name = {
                           operator       = "NOT_CONTAINS"
-                          resource_names = ["lab-test-claims-events"]
+                          resource_names = ["example-dynamodb-table"]
                         }
                       }
                     ]

--- a/internal/provider/resource_backup_policy_nested_groups_acc_test.go
+++ b/internal/provider/resource_backup_policy_nested_groups_acc_test.go
@@ -1,0 +1,153 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccBackupPolicyNestedGroups creates a CONDITIONAL policy whose selector nests
+// AND → OR → AND (type-scoped name excludes), matching the console resource selector UI.
+// Requires live Eon credentials plus EON_TEST_VAULT_ID.
+func TestAccBackupPolicyNestedGroups(t *testing.T) {
+	testAccRealEnvPreCheck(t, false)
+	vaultID := os.Getenv("EON_TEST_VAULT_ID")
+	if vaultID == "" {
+		t.Skip("EON_TEST_VAULT_ID must be set for backup policy acceptance tests")
+	}
+
+	resourceName := "eon_backup_policy.test"
+	name := fmt.Sprintf("tf-acc-nested-groups-%s", acctest.RandString(6))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRealProviderConfig() + testAccBackupPolicyNestedGroupsConfig(name, vaultID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_selector.resource_selection_mode", "CONDITIONAL"),
+					resource.TestCheckResourceAttr(resourceName, "resource_selector.expression.group.operator", "AND"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					// Nested OR group is the last top-level operand.
+					resource.TestCheckResourceAttr(resourceName, "resource_selector.expression.group.operands.2.group.operator", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "resource_selector.expression.group.operands.2.group.operands.0.group.operator", "AND"),
+					resource.TestCheckResourceAttr(resourceName, "resource_selector.expression.group.operands.2.group.operands.0.group.operands.0.resource_type.resource_types.0", "AWS_RDS"),
+					resource.TestCheckResourceAttr(resourceName, "resource_selector.expression.group.operands.2.group.operands.0.group.operands.1.resource_name.operator", "NOT_CONTAINS"),
+					resource.TestCheckResourceAttr(resourceName, "resource_selector.expression.group.operands.2.group.operands.0.group.operands.1.resource_name.resource_names.0", "db-test-users"),
+					resource.TestCheckResourceAttr(resourceName, "resource_selector.expression.group.operands.2.group.operands.1.group.operands.0.resource_type.resource_types.0", "AWS_DYNAMO_DB"),
+					resource.TestCheckResourceAttr(resourceName, "resource_selector.expression.group.operands.2.group.operands.1.group.operands.1.resource_name.resource_names.0", "lab-test-claims-events"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"created_at", "updated_at", "backup_plan.standard_plan.schedule_timezone"},
+			},
+		},
+	})
+}
+
+func testAccBackupPolicyNestedGroupsConfig(name, vaultID string) string {
+	return fmt.Sprintf(`
+resource "eon_backup_policy" "test" {
+  name    = %q
+  enabled = true
+
+  resource_selector = {
+    resource_selection_mode = "CONDITIONAL"
+
+    expression = {
+      group = {
+        operator = "AND"
+        operands = [
+          {
+            source_region = {
+              operator       = "IN"
+              source_regions = ["us-east-1"]
+            }
+          },
+          {
+            resource_type = {
+              operator       = "IN"
+              resource_types = ["AWS_RDS", "AWS_DYNAMO_DB"]
+            }
+          },
+          {
+            group = {
+              operator = "OR"
+              operands = [
+                {
+                  group = {
+                    operator = "AND"
+                    operands = [
+                      {
+                        resource_type = {
+                          operator       = "IN"
+                          resource_types = ["AWS_RDS"]
+                        }
+                      },
+                      {
+                        resource_name = {
+                          operator       = "NOT_CONTAINS"
+                          resource_names = ["db-test-users"]
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  group = {
+                    operator = "AND"
+                    operands = [
+                      {
+                        resource_type = {
+                          operator       = "IN"
+                          resource_types = ["AWS_DYNAMO_DB"]
+                        }
+                      },
+                      {
+                        resource_name = {
+                          operator       = "NOT_CONTAINS"
+                          resource_names = ["lab-test-claims-events"]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+
+  backup_plan = {
+    backup_policy_type = "STANDARD"
+    standard_plan = {
+      schedule_timezone = "UTC"
+      backup_schedules = [
+        {
+          vault_id       = %q
+          retention_days = 7
+          schedule_config = {
+            frequency = "DAILY"
+            daily_config = {
+              time_of_day_hour     = 3
+              time_of_day_minutes  = 0
+              start_window_minutes = 240
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+`, name, vaultID)
+}


### PR DESCRIPTION
## Summary
- Add nested `group` support (up to 3 levels) on `eon_backup_policy` resource selectors so Terraform can express the console pattern: top AND → nested OR → nested AND with leaf conditions
- Accept `DOES_NOT_CONTAIN` as an alias for `NOT_CONTAINS` on `resource_name`
- Add example `exclude_by_type_and_name` for type-scoped RDS/DynamoDB name excludes and regenerate docs

## Test plan
- [x] Unit tests: nested group flatten, schema nesting depth, operator alias
- [x] `go test ./internal/provider/ -run 'BackupPolicy|NormalizeResourceName'`
- [ ] Review example matches console selector UI (AND → OR → AND)
- [ ] Optional: apply example against eon-solutions with local provider build


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://eon.devinenterprise.com/review/eon-io/terraform-provider-eon/pull/125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->